### PR TITLE
fix(runtime): complete aborted partial tool batches

### DIFF
--- a/packages/runtime/src/session-abort.test.ts
+++ b/packages/runtime/src/session-abort.test.ts
@@ -1,0 +1,404 @@
+import { fauxAssistantMessage, fauxProvider, fauxText, fauxToolCall } from '@earendil-works/pi-ai';
+import { expect, it } from 'vitest';
+import type { PersistenceAdapter } from './agent-execution-store.ts';
+import type { ConversationRecord } from './conversation-records.ts';
+import {
+	init,
+	instrument,
+	useAgentStart,
+	useModel,
+	usePersistentState,
+	useSandbox,
+} from './index.ts';
+import { local, sqlite, start } from './node/index.ts';
+import type { ConversationStreamStore } from './runtime/conversation-stream-store.ts';
+import type { FlueObservation } from './types.ts';
+
+function recordDatabase(
+	beforeAppend?: (records: readonly ConversationRecord[]) => void | Promise<void>,
+) {
+	const database = sqlite();
+	const records: ConversationRecord[] = [];
+	const joins: Array<{ submissionId: string; afterRepair: boolean }> = [];
+	const adapter: PersistenceAdapter = {
+		migrate: () => database.migrate?.(),
+		close: () => database.close?.(),
+		async connect() {
+			const stores = await database.connect();
+			const stream = stores.conversationStreamStore;
+			const recording: ConversationStreamStore = {
+				createStream: (...args) => stream.createStream(...args),
+				acquireProducer: (...args) => stream.acquireProducer(...args),
+				async append(input) {
+					await beforeAppend?.(input.records);
+					const result = await stream.append(input);
+					records.push(...structuredClone(input.records));
+					return result;
+				},
+				read: (...args) => stream.read(...args),
+				getMeta: (...args) => stream.getMeta(...args),
+				subscribe: (...args) => stream.subscribe(...args),
+				...(stream.putFoldCheckpoint
+					? { putFoldCheckpoint: stream.putFoldCheckpoint.bind(stream) }
+					: {}),
+				...(stream.getFoldCheckpoint
+					? { getFoldCheckpoint: stream.getFoldCheckpoint.bind(stream) }
+					: {}),
+			};
+			return {
+				...stores,
+				conversationStreamStore: recording,
+				submissionStore: new Proxy(stores.submissionStore, {
+					get(target, key) {
+						if (key === 'claimJoinableSubmissions')
+							return (...args: Parameters<typeof target.claimJoinableSubmissions>) => {
+								joins.push({
+									submissionId: args[0].submissionId,
+									afterRepair: records.some((record) =>
+										record.id.startsWith('record_tool_repair_commit_'),
+									),
+								});
+								return target.claimJoinableSubmissions(...args);
+							};
+						const member = Reflect.get(target, key, target);
+						return typeof member === 'function' ? member.bind(target) : member;
+					},
+				}),
+			};
+		},
+	};
+	return { adapter, records, joins };
+}
+
+function untilAbort(signal: AbortSignal | undefined): Promise<never> {
+	if (!signal) throw new Error('The test requires an abort signal.');
+	return new Promise((_resolve, reject) => {
+		if (signal.aborted) reject(signal.reason);
+		else signal.addEventListener('abort', () => reject(signal.reason), { once: true });
+	});
+}
+
+async function createBatch(
+	options: {
+		complete?: boolean;
+		oneTool?: boolean;
+		beforeStart?: boolean;
+		beforeAppend?: (records: readonly ConversationRecord[]) => void | Promise<void>;
+	} = {},
+) {
+	const firstStarted = Promise.withResolvers<void>();
+	const counts = { first: 0, second: 0 };
+	const hookStarted = Promise.withResolvers<void>();
+	const publications: Array<{ event: FlueObservation; records: ConversationRecord[] }> = [];
+	const renderedState: string[] = [];
+	function AbortBatch() {
+		useModel('faux/m');
+		const [phase, setPhase] = usePersistentState('phase', 'initial');
+		renderedState.push(phase);
+		useAgentStart(async ({ signal }) => {
+			hookStarted.resolve();
+			if (options.beforeStart) await untilAbort(signal);
+			setPhase('stored');
+		});
+		useSandbox({
+			...local(),
+			tools: () => [
+				{
+					name: 'first',
+					label: 'First',
+					description: 'Wait for an abort.',
+					parameters: { type: 'object', properties: {} },
+					executionMode: 'sequential',
+					async execute(_id, _args, signal) {
+						counts.first += 1;
+						setPhase('pending');
+						firstStarted.resolve();
+						if (!options.complete) await untilAbort(signal);
+						return { details: {}, content: [{ type: 'text', text: 'First result.' }] };
+					},
+				},
+				{
+					name: 'second',
+					label: 'Second',
+					description: 'Count an execution.',
+					parameters: { type: 'object', properties: {} },
+					async execute() {
+						counts.second += 1;
+						return { details: {}, content: [{ type: 'text', text: 'Second result.' }] };
+					},
+				},
+			],
+		});
+		return 'Run the supplied test response.';
+	}
+	const faux = fauxProvider({ models: [{ id: 'm' }] });
+	faux.setResponses([
+		fauxAssistantMessage(
+			[
+				fauxToolCall('first', {}, { id: 'call_first' }),
+				...(options.oneTool ? [] : [fauxToolCall('second', {}, { id: 'call_second' })]),
+			],
+			{ stopReason: 'toolUse' },
+		),
+		fauxAssistantMessage([fauxText('Next submission succeeds.')], { stopReason: 'stop' }),
+	]);
+	const database = recordDatabase(options.beforeAppend);
+	const events: FlueObservation[] = [];
+	const errors: unknown[] = [];
+	const disposeInstrumentation = instrument({
+		dispose() {},
+		observe: (event) => {
+			events.push(event);
+			if (event.type === 'tool')
+				publications.push({ event, records: structuredClone(database.records) });
+		},
+		async interceptor(_operation, _context, next) {
+			try {
+				return await next();
+			} catch (error) {
+				errors.push(error);
+				throw error;
+			}
+		},
+	});
+	const runtime = await start({
+		agents: [AbortBatch],
+		db: database.adapter,
+		providers: [faux.provider],
+		env: {},
+	}).catch(async (error: unknown) => {
+		await disposeInstrumentation();
+		throw error;
+	});
+	const agent = init(AbortBatch, { id: 'abort-batch' });
+	return {
+		agent,
+		firstStarted,
+		hookStarted,
+		counts,
+		errors,
+		events,
+		records: database.records,
+		joins: database.joins,
+		renderedState,
+		publications,
+		faux,
+		async [Symbol.asyncDispose]() {
+			await agent.abort();
+			await runtime.stop();
+			await disposeInstrumentation();
+		},
+	};
+}
+
+it('commits an aborted partial batch before the failure assistant starts', async () => {
+	await using batch = await createBatch();
+	const { agent, firstStarted, counts, errors, events, records, renderedState, publications } =
+		batch;
+	const receipt = await agent.dispatch('Run both tools.');
+	await firstStarted.promise;
+	await agent.abort();
+	await expect(agent.read(receipt)).rejects.toMatchObject({
+		name: 'AgentRunError',
+		message: expect.stringContaining('aborted'),
+	});
+	expect(counts.second).toBe(0);
+	const refusals = errors.filter(
+		(error) => error instanceof Error && error.name === 'ConversationRecordInvariantError',
+	);
+	expect(refusals, 'An abort must not emit a conversation record refusal.').toHaveLength(0);
+	const abortedMessages = events.filter(
+		(event) =>
+			event.type === 'message_end' &&
+			event.message.role === 'assistant' &&
+			event.message.stopReason === 'aborted',
+	);
+	expect(abortedMessages).toHaveLength(1);
+	expect(abortedMessages).toMatchObject([
+		{ message: { errorMessage: expect.stringMatching(/aborted/i) } },
+	]);
+	expect(JSON.stringify(abortedMessages)).not.toContain('ConversationRecordInvariantError');
+	expect(JSON.stringify(abortedMessages)).not.toContain('conversation stream contract');
+	const outcomes = records.filter((record) => record.type === 'tool_outcome');
+	expect(outcomes.map((record) => record.toolCallId)).toEqual(['call_first', 'call_second']);
+	expect(outcomes[1]).toMatchObject({
+		isError: true,
+		content: [
+			{
+				type: 'text',
+				text: JSON.stringify({
+					type: 'interrupted',
+					message: 'Tool execution was interrupted before completion. The outcome is unknown.',
+				}),
+			},
+		],
+	});
+	const commits = records.filter((record) => record.type === 'tool_results_committed');
+	expect(commits).toHaveLength(1);
+	expect(commits[0]?.outcomeIds).toEqual(outcomes.map((record) => record.id));
+	const commitIndex = records.findIndex((record) => record.type === 'tool_results_committed');
+	const starts = records.flatMap((record, index) =>
+		record.type === 'assistant_message_started' ? [index] : [],
+	);
+	expect(starts).toHaveLength(2);
+	expect(starts[1]).toBeDefined();
+	expect(commitIndex < (starts[1] ?? -1)).toBe(true);
+	expect(records.filter((record) => record.type === 'submission_settled')).toMatchObject([
+		{ outcome: 'aborted' },
+	]);
+	expect(publications).toHaveLength(1);
+	expect(publications[0]?.records).toContainEqual(commits[0]);
+	expect(
+		publications[0]?.records.filter(
+			(record) => record.type === 'tool_outcome' && record.toolCallId === 'call_first',
+		),
+	).toEqual([outcomes[0]]);
+	const advisory = records.find(
+		(record) => record.type === 'signal' && record.signalType === 'submission_aborted',
+	);
+	expect(advisory).toMatchObject({
+		attributes: { interruptedTools: JSON.stringify([{ name: 'second', id: 'call_second' }]) },
+	});
+	expect(records.filter((record) => record.type === 'state_write')).toMatchObject([
+		{ name: 'phase', value: 'stored' },
+	]);
+	expect(renderedState).not.toContain('pending');
+	await expect(agent.read(await agent.dispatch('Continue.'))).resolves.toMatchObject({
+		text: 'Next submission succeeds.',
+	});
+	expect(renderedState).not.toContain('pending');
+	expect(renderedState.at(-1)).toBe('stored');
+});
+
+it('keeps normal two-tool execution and state commits', async () => {
+	await using batch = await createBatch({ complete: true });
+	await expect(
+		batch.agent.read(await batch.agent.dispatch('Run both tools.')),
+	).resolves.toMatchObject({ text: 'Next submission succeeds.' });
+	expect(batch.counts).toEqual({ first: 1, second: 1 });
+	expect(batch.records.filter((record) => record.type === 'tool_results_committed')).toHaveLength(
+		1,
+	);
+	expect(
+		batch.records
+			.filter((record) => record.type === 'tool_outcome')
+			.map((record) => record.isError),
+	).toEqual([false, false]);
+	expect(batch.records.filter((record) => record.type === 'state_write')).toMatchObject([
+		{ value: 'stored' },
+		{ value: 'pending' },
+	]);
+	expect(batch.publications).toHaveLength(2);
+});
+
+it('keeps a complete one-tool abort on the normal commit path', async () => {
+	await using batch = await createBatch({ oneTool: true });
+	const receipt = await batch.agent.dispatch('Run one tool.');
+	await batch.firstStarted.promise;
+	await batch.agent.abort();
+	await expect(batch.agent.read(receipt)).rejects.toMatchObject({ name: 'AgentRunError' });
+	expect(batch.counts).toEqual({ first: 1, second: 0 });
+	expect(batch.records.filter((record) => record.type === 'tool_outcome')).toHaveLength(1);
+	expect(batch.records.filter((record) => record.type === 'tool_results_committed')).toMatchObject([
+		{ id: expect.stringMatching(/^record_tool_results_committed_/) },
+	]);
+	expect(batch.records.filter((record) => record.type === 'submission_settled')).toMatchObject([
+		{ outcome: 'aborted' },
+	]);
+	expect(batch.records.some((record) => record.id.startsWith('record_tool_repair_'))).toBe(false);
+});
+
+it('aborts before model work without creating a tool batch', async () => {
+	await using batch = await createBatch({ beforeStart: true });
+	const receipt = await batch.agent.dispatch('Stop before the model.');
+	await batch.hookStarted.promise;
+	await batch.agent.abort();
+	await expect(batch.agent.read(receipt)).rejects.toMatchObject({ name: 'AgentRunError' });
+	expect(batch.faux.state.callCount).toBe(0);
+	expect(batch.counts).toEqual({ first: 0, second: 0 });
+	expect(
+		batch.records.filter(
+			(record) => record.type === 'tool_outcome' || record.type === 'tool_results_committed',
+		),
+	).toEqual([]);
+	expect(batch.records.filter((record) => record.type === 'submission_settled')).toMatchObject([
+		{ outcome: 'aborted' },
+	]);
+});
+
+it('leaves a queued submission for its next attempt after abort repair', async () => {
+	const repairStarted = Promise.withResolvers<void>();
+	const finishRepair = Promise.withResolvers<void>();
+	await using batch = await createBatch({
+		async beforeAppend(records) {
+			if (!records.some((record) => record.id.startsWith('record_tool_repair_commit_'))) return;
+			repairStarted.resolve();
+			await finishRepair.promise;
+		},
+	});
+	try {
+		const receipt = await batch.agent.dispatch('Run both tools.');
+		await batch.firstStarted.promise;
+		await batch.agent.abort();
+		await repairStarted.promise;
+		const next = await batch.agent.dispatch('Run after the aborted attempt.');
+		finishRepair.resolve();
+		await expect(batch.agent.read(receipt)).rejects.toMatchObject({ name: 'AgentRunError' });
+		expect(
+			batch.joins.filter((join) => join.submissionId === receipt.submissionId && join.afterRepair),
+		).toEqual([]);
+		await expect(batch.agent.read(next)).resolves.toMatchObject({
+			text: 'Next submission succeeds.',
+		});
+		expect(batch.records.filter((record) => record.type === 'submission_settled')).toMatchObject([
+			{ submissionId: receipt.submissionId, outcome: 'aborted' },
+			{ submissionId: next.submissionId, outcome: 'completed' },
+		]);
+	} finally {
+		finishRepair.resolve();
+	}
+});
+
+it('retries a transient commit failure without repeating stored outcomes', async () => {
+	const failure = new Error('Test store rejects the repair commit.');
+	let failuresRemaining = 1;
+	await using batch = await createBatch({
+		beforeAppend(records) {
+			if (
+				failuresRemaining === 0 ||
+				!records.some((record) => record.id.startsWith('record_tool_repair_commit_'))
+			)
+				return;
+			failuresRemaining -= 1;
+			throw failure;
+		},
+	});
+	const receipt = await batch.agent.dispatch('Run both tools.');
+	await batch.firstStarted.promise;
+	await batch.agent.abort();
+	await expect(batch.agent.read(receipt)).rejects.toMatchObject({ name: 'AgentRunError' });
+	expect(failuresRemaining).toBe(0);
+	expect(batch.counts).toEqual({ first: 1, second: 0 });
+	expect(
+		batch.records
+			.filter((record) => record.type === 'tool_outcome')
+			.map((record) => record.toolCallId),
+	).toEqual(['call_first', 'call_second']);
+	expect(batch.records.filter((record) => record.type === 'tool_results_committed')).toHaveLength(
+		1,
+	);
+	expect(batch.publications).toHaveLength(1);
+	expect(
+		batch.records.filter(
+			(record) => record.type === 'signal' && record.signalType === 'submission_aborted',
+		),
+	).toMatchObject([
+		{ attributes: { interruptedTools: JSON.stringify([{ name: 'second', id: 'call_second' }]) } },
+	]);
+	expect(batch.records.filter((record) => record.type === 'submission_settled')).toMatchObject([
+		{ outcome: 'aborted' },
+	]);
+	await batch.agent.abort();
+	await expect(batch.agent.read(receipt)).rejects.toMatchObject({ name: 'AgentRunError' });
+	expect(batch.records.filter((record) => record.type === 'submission_settled')).toHaveLength(1);
+});

--- a/packages/runtime/src/session-terminal.test.ts
+++ b/packages/runtime/src/session-terminal.test.ts
@@ -1,0 +1,330 @@
+import { fauxAssistantMessage, fauxProvider } from '@earendil-works/pi-ai';
+import { expect, it } from 'vitest';
+import { type ConversationRecord, encodeCanonicalId } from './conversation-records.ts';
+import { ConversationRecordWriter } from './conversation-writer.ts';
+import { InMemoryAttachmentStore } from './runtime/attachment-store.ts';
+import { InMemoryConversationStreamStore } from './runtime/conversation-stream-store.ts';
+import { generateTaskId } from './runtime/ids.ts';
+import { Session } from './session.ts';
+import { createTaskSessionName } from './session-identity.ts';
+
+const submissionId = 'submission_test';
+const requestId = 'entry_request';
+const scope = { conversationId: 'conversation_test', harness: 'default', session: 'default' };
+const envelope = {
+	...scope,
+	v: 1 as const,
+	timestamp: '2026-09-11T00:00:00.000Z',
+	submissionId,
+	attemptId: 'attempt_test',
+};
+const appendOptions = { submission: { submissionId, attemptId: envelope.attemptId } };
+const terminal = {
+	submissionId,
+	kind: 'dispatch' as const,
+	reason: 'aborted' as const,
+	message: 'Stopped.',
+};
+const unknownContent = [
+	{
+		type: 'text' as const,
+		text: JSON.stringify({
+			type: 'interrupted',
+			message: 'Tool execution was interrupted before completion. The outcome is unknown.',
+		}),
+	},
+];
+
+class TestStream extends InMemoryConversationStreamStore {
+	readonly records: ConversationRecord[] = [];
+	refuseCommit = false;
+	readonly failure = new Error('Test storage refuses the repair commit.');
+	override async append(input: Parameters<InMemoryConversationStreamStore['append']>[0]) {
+		if (
+			this.refuseCommit &&
+			input.records.some((record) => record.type === 'tool_results_committed')
+		)
+			throw this.failure;
+		const result = await super.append(input);
+		this.records.push(...structuredClone(input.records));
+		return result;
+	}
+}
+
+async function newWriter(store: TestStream, producerId: string) {
+	return ConversationRecordWriter.create({
+		store,
+		path: 'test-stream',
+		identity: { agentName: 'Test', instanceId: 'terminal' },
+		producerId,
+	});
+}
+
+async function newSession(writer: ConversationRecordWriter) {
+	const conversation = await writer.getConversation(scope.conversationId);
+	if (!conversation) throw new Error('The test conversation is missing.');
+	const model = fauxProvider({ models: [{ id: 'm' }] }).getModel();
+	return new Session({
+		name: scope.session,
+		conversation,
+		conversationWriter: writer,
+		attachmentStore: new InMemoryAttachmentStore(),
+		config: {
+			systemPrompt: 'Test terminal records.',
+			skills: {},
+			model,
+			resolveModel: () => model,
+		},
+		envSlot: { env: undefined, toolFactory: undefined, rediscoverNeeded: false },
+	});
+}
+
+async function seedBatch(store: TestStream) {
+	const writer = await newWriter(store, 'initial');
+	await writer.ensureConversation({
+		...scope,
+		kind: 'root',
+		affinityKey: 'test',
+		createdAt: envelope.timestamp,
+	});
+	const response = fauxAssistantMessage([], { stopReason: 'toolUse' });
+	await writer.append(
+		[
+			{
+				...envelope,
+				id: 'record_start',
+				type: 'assistant_message_started',
+				messageId: requestId,
+				parentId: null,
+				modelInfo: { api: response.api, provider: response.provider, model: response.model },
+			},
+			{
+				...envelope,
+				id: 'record_call_first',
+				type: 'assistant_tool_call',
+				messageId: requestId,
+				blockId: 'block_first',
+				blockIndex: 0,
+				toolCallId: 'call_first',
+				name: 'first',
+				arguments: {},
+			},
+			{
+				...envelope,
+				id: 'record_call_task',
+				type: 'assistant_tool_call',
+				messageId: requestId,
+				blockId: 'block_task',
+				blockIndex: 1,
+				toolCallId: 'call_task',
+				name: 'task',
+				arguments: {},
+			},
+			{
+				...envelope,
+				id: 'record_complete',
+				type: 'assistant_message_completed',
+				messageId: requestId,
+				stopReason: 'toolUse',
+				usage: response.usage,
+			},
+			{
+				...envelope,
+				id: 'record_first_outcome',
+				type: 'tool_outcome',
+				assistantMessageId: requestId,
+				toolCallId: 'call_first',
+				toolName: 'first',
+				isError: true,
+				content: unknownContent,
+			},
+			{
+				...envelope,
+				id: 'record_stored_state',
+				type: 'state_write',
+				name: 'phase',
+				value: 'stored',
+			},
+		],
+		appendOptions,
+	);
+	const taskId = generateTaskId();
+	const child = {
+		type: 'task' as const,
+		conversationId: 'conversation_child',
+		harness: scope.harness,
+		session: createTaskSessionName(scope.session, taskId),
+		taskId,
+		parentToolCallId: 'call_task',
+		parentAssistantEntryId: requestId,
+	};
+	await writer.ensureChildConversation({
+		parent: scope,
+		child: {
+			...child,
+			kind: 'task',
+			affinityKey: 'child',
+			createdAt: envelope.timestamp,
+			parentConversationId: scope.conversationId,
+		},
+		ref: child,
+	});
+	return { writer, child };
+}
+
+it('keeps child references and interrupted IDs across fresh terminal sessions', async () => {
+	const store = new TestStream();
+	const { writer, child } = await seedBatch(store);
+	const firstOutcome = structuredClone(
+		store.records.find((record) => record.id === 'record_first_outcome'),
+	);
+	const session = await newSession(writer);
+	try {
+		await expect(session.recordSubmissionTerminal(terminal)).resolves.toEqual([
+			{ name: 'task', id: 'call_task' },
+		]);
+	} finally {
+		await session.close();
+	}
+	const before = structuredClone(store.records);
+	const restarted = await newSession(await newWriter(store, 'restarted'));
+	try {
+		await expect(restarted.recordSubmissionTerminal(terminal)).resolves.toEqual([
+			{ name: 'task', id: 'call_task' },
+		]);
+		await expect(restarted.recordSubmissionTerminal(terminal)).resolves.toEqual([
+			{ name: 'task', id: 'call_task' },
+		]);
+	} finally {
+		await restarted.close();
+	}
+	expect(store.records).toEqual(before);
+	expect(store.records.filter((record) => record.id === 'record_first_outcome')).toEqual([
+		firstOutcome,
+	]);
+	expect(store.records.filter((record) => record.type === 'child_session_retained')).toMatchObject([
+		{ child },
+	]);
+	const outcomes = store.records.filter((record) => record.type === 'tool_outcome');
+	expect(outcomes).toHaveLength(2);
+	expect(outcomes[1]).toMatchObject({
+		content: [
+			{
+				type: 'text',
+				text: JSON.stringify({
+					type: 'interrupted',
+					message: 'Tool execution was interrupted before completion. The outcome is unknown.',
+					childConversationId: child.conversationId,
+				}),
+			},
+		],
+	});
+	expect(store.records.filter((record) => record.type === 'tool_results_committed')).toMatchObject([
+		{ outcomeIds: outcomes.map((outcome) => outcome.id) },
+	]);
+	expect(store.records.filter((record) => record.type === 'signal')).toHaveLength(1);
+	expect(store.records.filter((record) => record.type === 'state_write')).toMatchObject([
+		{ name: 'phase', value: 'stored' },
+	]);
+});
+
+it('propagates a commit failure and completes the same repair after restart', async () => {
+	const store = new TestStream();
+	const { writer } = await seedBatch(store);
+	store.refuseCommit = true;
+	const interrupted = await newSession(writer);
+	try {
+		await expect(interrupted.recordSubmissionTerminal(terminal)).rejects.toBe(store.failure);
+	} finally {
+		await interrupted.close();
+	}
+	const appendedOutcomes = structuredClone(
+		store.records.filter((record) => record.type === 'tool_outcome'),
+	);
+	expect(appendedOutcomes).toHaveLength(2);
+	expect(
+		store.records.filter(
+			(record) => record.type === 'tool_results_committed' || record.type === 'signal',
+		),
+	).toEqual([]);
+	store.refuseCommit = false;
+	const restarted = await newSession(await newWriter(store, 'retry'));
+	try {
+		await expect(restarted.recordSubmissionTerminal(terminal)).resolves.toEqual([
+			{ name: 'task', id: 'call_task' },
+		]);
+		await expect(restarted.recordSubmissionTerminal(terminal)).resolves.toEqual([
+			{ name: 'task', id: 'call_task' },
+		]);
+	} finally {
+		await restarted.close();
+	}
+	expect(store.records.filter((record) => record.type === 'tool_outcome')).toEqual(
+		appendedOutcomes,
+	);
+	expect(store.records.filter((record) => record.type === 'tool_results_committed')).toHaveLength(
+		1,
+	);
+	expect(store.records.filter((record) => record.type === 'signal')).toHaveLength(1);
+});
+
+it('refuses terminal cleanup of another submission without repairing its batch', async () => {
+	const store = new TestStream();
+	const { writer } = await seedBatch(store);
+	const before = structuredClone(store.records);
+	const session = await newSession(writer);
+	try {
+		await expect(
+			session.recordSubmissionTerminal({ ...terminal, submissionId: 'another_submission' }),
+		).rejects.toMatchObject({ name: 'ConversationRecordInvariantError' });
+	} finally {
+		await session.close();
+	}
+	expect(store.records).toEqual(before);
+});
+
+it.each(['missing', 'duplicate', 'reversed'] as const)(
+	'refuses a non-aborted %s result list',
+	async (kind) => {
+		const store = new TestStream();
+		const { writer } = await seedBatch(store);
+		await writer.append(
+			[
+				{
+					...envelope,
+					id: 'record_task_outcome',
+					type: 'tool_outcome',
+					assistantMessageId: requestId,
+					toolCallId: 'call_task',
+					toolName: 'task',
+					isError: false,
+					content: [{ type: 'text', text: 'Stored task result.' }],
+				},
+			],
+			appendOptions,
+		);
+		const before = structuredClone(store.records);
+		const outcomeIds =
+			kind === 'missing'
+				? ['record_first_outcome']
+				: kind === 'duplicate'
+					? ['record_first_outcome', 'record_first_outcome']
+					: ['record_task_outcome', 'record_first_outcome'];
+		await expect(
+			writer.append(
+				[
+					{
+						...envelope,
+						id: `record_tool_results_committed_${encodeCanonicalId(requestId)}`,
+						type: 'tool_results_committed',
+						assistantMessageId: requestId,
+						parentId: requestId,
+						outcomeIds,
+					},
+				],
+				appendOptions,
+			),
+		).rejects.toMatchObject({ name: 'ConversationRecordInvariantError' });
+		expect(store.records).toEqual(before);
+	},
+);

--- a/packages/runtime/src/session.ts
+++ b/packages/runtime/src/session.ts
@@ -2237,7 +2237,7 @@ export class Session implements FlueSession, AgentSubmissionSession {
 		});
 
 		this.eventCallback = options.onAgentEvent;
-		this.agentLoop.subscribe(async (event) => {
+		this.agentLoop.subscribe(async (event, signal) => {
 			switch (event.type) {
 				case 'agent_start':
 					this.emit({ type: 'agent_start' });
@@ -2600,6 +2600,47 @@ export class Session implements FlueSession, AgentSubmissionSession {
 				}
 				case 'turn_end': {
 					const turnId = this.activeTurnId ?? generateTurnId();
+					if (signal.aborted && this.canonicalToolRequestMessageId) {
+						const requestId = this.canonicalToolRequestMessageId;
+						const conversation = await this.requireConversation();
+						const request = conversation.entries.get(requestId);
+						if (
+							conversation.activeLeafId === requestId &&
+							request?.type === 'message' &&
+							request.submissionId === this.activeSubmissionId &&
+							request.message.role === 'assistant' &&
+							request.message.stopReason === 'toolUse'
+						) {
+							const calls = request.message.content.filter((block) => block.type === 'toolCall');
+							let previousIndex = -1;
+							const orderedResults = event.toolResults.every((result) => {
+								const index = calls.findIndex((call) => call.id === result.toolCallId);
+								if (
+									index <= previousIndex ||
+									calls[index]?.name !== result.toolName ||
+									!conversation.toolOutcomes.has(toolOutcomeKey(requestId, result.toolCallId))
+								)
+									return false;
+								previousIndex = index;
+								return true;
+							});
+							if (event.toolResults.length < calls.length && orderedResults) {
+								// Pi can stop a sequential batch after one result. Commit its
+								// missing outcomes before Pi starts the aborted assistant.
+								await this.settleTrailingToolBatch({ submissionId: this.activeSubmissionId });
+								this.hookState?.drain();
+								this.canonicalToolRequestMessageId = undefined;
+								this.lastCommittedToolBatch = undefined;
+								this.activeJoinSource = undefined;
+								this.activeJoinSignal = undefined;
+								for (const result of event.toolResults) {
+									this.pendingToolPublications.get(result.toolCallId)?.();
+									this.pendingToolPublications.delete(result.toolCallId);
+								}
+								throw abortErrorFor(signal);
+							}
+						}
+					}
 					const committedToolResults = event.toolResults.length > 0;
 					if (committedToolResults) {
 						const parentId = await this.conversationWriter.getConversationLeaf(this.conversationId);
@@ -3444,9 +3485,37 @@ export class Session implements FlueSession, AgentSubmissionSession {
 		// contract of terminalization, not a caller responsibility: every
 		// terminal path (retry exhaustion, timeout, post-input interruption,
 		// abort) routes through here.
-		const interruptedTools = await this.settleDanglingConversationState({
+		await this.settleDanglingConversationState({
 			submissionId: input.submissionId,
 		});
+		// The turn writer can commit repairs before this new Session starts.
+		// Match stored repair IDs and committed results, never result text.
+		const conversation = await this.requireConversation();
+		const interruptedTools: InterruptedToolCallRef[] = [];
+		for (const entry of conversation.entries.values()) {
+			if (
+				entry.type !== 'message' ||
+				entry.submissionId !== input.submissionId ||
+				entry.message.role !== 'assistant'
+			)
+				continue;
+			for (const call of entry.message.content) {
+				if (call.type !== 'toolCall') continue;
+				const result = conversation.entries.get(toolResultEntryId(entry.id, call.id));
+				if (result?.type !== 'message' || result.message.role !== 'toolResult') continue;
+				const repair = await this.conversationWriter.getRecord(
+					`record_tool_repair_outcome_${encodeCanonicalId(entry.id)}_${encodeCanonicalId(call.id)}`,
+				);
+				if (
+					repair?.type === 'tool_outcome' &&
+					repair.conversationId === this.conversationId &&
+					repair.toolName === call.name &&
+					repair.isError &&
+					result.message.isError
+				)
+					interruptedTools.push({ name: call.name, id: call.id });
+			}
+		}
 		let body = input.message;
 		if (interruptedTools.length > 0) {
 			const toolList = interruptedTools.map((t) => `  - ${t.name} (${t.id})`).join('\n');

--- a/packages/runtime/vitest.config.ts
+++ b/packages/runtime/vitest.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+	test: { include: ['src/**/*.test.ts'] },
+});


### PR DESCRIPTION
An abort during the first of two sequential tools can give Flue one result for two calls. The turn writer rejects that incomplete commit. Pi then starts its failure assistant while the batch is still open, which causes another record refusal.

The awaited `turn_end` subscriber now uses Pi's public abort signal. For the current submission's incomplete batch at the active leaf, it preserves stored outcomes and uses the existing repair helpers to add unknown interruption results. It commits the complete batch before publishing results and throwing the abort error. It also drops pending state writes and clears render and join tracking for that attempt.

Terminal cleanup reads committed repair IDs so a fresh Session keeps the interrupted tool IDs. The change preserves child references, repeated cleanup, and storage error propagation. It adds no package dependency or record type.

Validation uses public `start` / `init` / `dispatch` / `abort` / `read`, a faux provider, local SQLite, and the real conversation writer. Twelve tests cover normal, one-tool, pre-start, queued, interrupted-state, restart, repeated-cleanup, storage-failure, other-submission, and malformed-list cases.

The regression fails on the base and when the fix is removed:

```text
AssertionError: An abort must not emit a conversation record refusal.: expected [ …(1) ] to have a length of +0 but got 1
```

All 12 tests, runtime types, runtime build, affected-file lint, and formatting pass. Eight code mutations fail at the intended checks. Biome reports five existing optional-chain warnings. Runtime-filtered Knip fails with the same missing example dependencies and unused declarations on the base and this change.

Commands:

```sh
pnpm --filter @flue/runtime test --maxWorkers=1
pnpm --filter @flue/runtime check:types
pnpm --filter @flue/runtime build
pnpm exec biome lint packages/runtime/src/session.ts packages/runtime/src/session-abort.test.ts packages/runtime/src/session-terminal.test.ts packages/runtime/vitest.config.ts
pnpm exec prettier --check packages/runtime/src/session.ts packages/runtime/src/session-abort.test.ts packages/runtime/src/session-terminal.test.ts packages/runtime/vitest.config.ts
pnpm exec knip --workspace packages/runtime
```

The source and tests receive a staff self-review. This is not an independent maintainer review. No live provider call or package publication occurs. A skipped call remains an unknown external outcome. The change does not repair old stored sessions or change the coordinator's broader storage retry policy.

Tracking: [RUN-7611](https://linear.app/runner-app/issue/RUN-7611/complete-aborted-flue-tool-batches-before-failure-messages).
