### PR TITLE
feat(runtime): observe committed submission attempt changes

### DIFF
--- a/apps/docs/src/content/docs/reference/events.md
+++ b/apps/docs/src/content/docs/reference/events.md
@@ -117,6 +117,7 @@ The v3 vocabulary contains 27 event types:
 - Agent lifecycle — [`agent_start`, `agent_end`, `idle`](#agent_start-agent_end-idle)
 - Submission lifecycle — [`submission_queued`, `submission_running`](#submission_queued-submission_running), [`submission_settled`](#submission_settled)
 - Recovery — [`submission_recovery`](#submission_recovery)
+- Attempt changes — [`submission_attempt_changed`](#submission_attempt_changed)
 - Operations — [`operation_start`, `operation`](#operation_start-operation)
 - Model turns — [`turn_start`, `turn_request`, `turn`, `turn_messages`](#turn_start-turn_request-turn-turn_messages)
 - Messages and deltas — [`message_start`, `message_end`, `text_delta`, `thinking_start`, `thinking_delta`, `thinking_end`, `toolcall_delta`](#message-and-delta-events)
@@ -190,6 +191,30 @@ observe((event) => {
 ```
 
 The pattern converges across process restarts and Durable Object eviction: a fresh isolate's recovery re-emits `submission_running` for every interrupted submission (and `submission_queued` re-fires on admission replays) before those submissions settle, so the new observer's busy set rebuilds itself. The at-least-once emissions are absorbed by the set semantics.
+
+### `submission_attempt_changed`
+
+```ts
+{
+  type: 'submission_attempt_changed';
+  submissionId: string;
+  kind: 'dispatch' | 'direct';
+  operation: 'claim_submission' | 'replace_submission_attempt';
+  previous: { attemptId: string | null; attemptCount: number } | null;
+  current: { attemptId: string; attemptCount: number };
+  maxAttempts: number;
+  reason: 'queued_claim' | 'interrupted_transcript';
+  position: { lastStreamOffset: string | null; pendingToolCount: number | null };
+}
+```
+
+Cloudflare and Node emit this event immediately after a guarded claim or replacement returns a changed row, before starting its execution. A rejected stale change returns no row and emits no event. The event uses the coordinator's envelope and event sequence, with `agentName` and `instanceId`.
+
+`current`, `submissionId`, `kind`, and `maxAttempts` come from the returned row. `previous` contains the observed prior attempt. Its `attemptId` is null when the observed row has no attempt ID. A queued row can be claimed and requeued after it is listed. If its observed count is no longer one below the returned count, the entire `previous` snapshot is null. Counts are submission attempts, independent of HTTP retries inside a model request.
+
+`reason` is `queued_claim` for a claim and `interrupted_transcript` for a replacement. The latter names the existing inspection result; it does not identify why the process stopped. `position` comes from that inspection, without another query. Claims have no inspection, so both fields are null. The built-in recovery inspection supplies the stream offset but does not count unresolved tool calls; `pendingToolCount` stays null. Null means unknown, not zero.
+
+Delivery is live and does not block execution. Observer failures are contained. A process can stop after the store commits and before the event reaches an observer. There is no replay, outbox, or exactly-once guarantee. The event does not change recovery, execution, or settlement.
 
 ### `submission_recovery`
 
@@ -538,17 +563,18 @@ Log events are runtime events only: the model never sees them and they never app
 For one durable submission whose `prompt` operation contains a single tool-calling turn, events arrive in this order:
 
 1. `submission_queued` at admission
-2. `submission_running` when the attempt starts processing
-3. `operation_start`, `agent_start`
-4. `message_start` / `message_end` for the user message
-5. `turn_start`, `turn_request`
-6. `message_start` for the assistant message; `text_delta`, `thinking_*`, and `toolcall_delta` interleave while it streams
-7. `turn`, then `message_end` for the completed assistant message
-8. per tool call: `tool_start` when execution begins, then `message_start` / `message_end` for its tool-result message when it finishes
-9. the terminal `tool` events when the batch commits, then `turn_messages`
-10. further turns repeat from step 5 until a turn produces no tool calls
-11. `agent_end`, `operation`, `idle`
-12. `submission_settled` when the submission settles
+2. `submission_attempt_changed` when the claim returns its changed row
+3. `submission_running` when the attempt starts processing
+4. `operation_start`, `agent_start`
+5. `message_start` / `message_end` for the user message
+6. `turn_start`, `turn_request`
+7. `message_start` for the assistant message; `text_delta`, `thinking_*`, and `toolcall_delta` interleave while it streams
+8. `turn`, then `message_end` for the completed assistant message
+9. per tool call: `tool_start` when execution begins, then `message_start` / `message_end` for its tool-result message when it finishes
+10. the terminal `tool` events when the batch commits, then `turn_messages`
+11. further turns repeat from step 6 until a turn produces no tool calls
+12. `agent_end`, `operation`, `idle`
+13. `submission_settled` when the submission settles
 
 The sequence describes the uncontended path. A delivery that joins an already-busy conversation can interleave additional user `message_start` / `message_end` pairs at turn boundaries — such a joined delivery contributes its own `submission_queued` and `submission_settled` but no `submission_running`.
 

--- a/packages/runtime/src/cloudflare/agent-coordinator.ts
+++ b/packages/runtime/src/cloudflare/agent-coordinator.ts
@@ -20,6 +20,7 @@ import {
 	type createAgentSubmissionSessionHandler,
 	createDirectAgentSubmissionInput,
 	createDispatchAgentSubmissionInput,
+	emitSubmissionAttemptChanged,
 	ensureInstanceIdentity,
 	finalizePendingSettlement,
 	type InstanceContactAdmission,
@@ -748,7 +749,15 @@ class CloudflareAgentCoordinator {
 					ownerId: this.instance.ctx.id.toString(),
 					leaseExpiresAt: 0,
 				});
-				if (claimed) toStart.push(claimed);
+				if (claimed) {
+					emitSubmissionAttemptChanged(
+						submission,
+						claimed,
+						'claim_submission',
+						this.emitCoordinatorEvent,
+					);
+					toStart.push(claimed);
+				}
 			}
 		} catch (error) {
 			console.error(

--- a/packages/runtime/src/node/agent-coordinator.ts
+++ b/packages/runtime/src/node/agent-coordinator.ts
@@ -17,6 +17,7 @@ import {
 	adoptKeyedSubmissionReplay,
 	createDirectAgentSubmissionInput,
 	createDispatchAgentSubmissionInput,
+	emitSubmissionAttemptChanged,
 	ensureInstanceIdentity,
 	finalizePendingSettlement,
 	type InstanceContactAdmission,
@@ -429,6 +430,12 @@ export function createNodeAgentCoordinator(options: {
 				leaseExpiresAt: Date.now() + LEASE_DURATION_MS,
 			});
 			if (!claimed) continue;
+			emitSubmissionAttemptChanged(
+				submission,
+				claimed,
+				'claim_submission',
+				coordinatorEventEmitter(claimed.input),
+			);
 			progressed = true;
 			spawnSubmissionTask(claimed);
 		}

--- a/packages/runtime/src/runtime/agent-submissions.ts
+++ b/packages/runtime/src/runtime/agent-submissions.ts
@@ -26,7 +26,7 @@ import {
 } from '../errors.ts';
 import { type FlueTraceCarrier, interceptExecution } from '../execution-interceptor.ts';
 import { getInternalSession } from '../session.ts';
-import type { Agent, CallHandle, DeliveredMessage } from '../types.ts';
+import type { Agent, CallHandle, DeliveredMessage, FlueEventInput } from '../types.ts';
 import { type AttachmentStore, createAttachmentRef } from './attachment-store.ts';
 import type { DispatchInput } from './dispatch-queue.ts';
 import type { CoordinatorEventEmitter } from './events.ts';
@@ -78,6 +78,13 @@ export interface InterruptedToolCallRef {
 
 export type AgentSubmissionInspection = 'absent' | 'completed' | 'interrupted';
 
+type SubmissionAttemptChanged = Extract<FlueEventInput, { type: 'submission_attempt_changed' }>;
+
+export interface AgentSubmissionInspectionSnapshot {
+	readonly state: AgentSubmissionInspection;
+	readonly position: SubmissionAttemptChanged['position'];
+}
+
 export interface ProcessAgentSubmissionOptions {
 	submissionAttempt?: SubmissionAttemptRef;
 	onInputApplied?: (durability: SubmissionDurability) => Promise<void> | void;
@@ -120,7 +127,7 @@ export interface AgentSubmissionSession {
 	readonly conversationId: string;
 	inspectSubmissionInput(
 		input: AgentSubmissionInput,
-	): Promise<AgentSubmissionInspection> | AgentSubmissionInspection;
+	): Promise<AgentSubmissionInspectionSnapshot> | AgentSubmissionInspectionSnapshot;
 	processSubmissionInput(
 		input: AgentSubmissionInput,
 		options?: ProcessAgentSubmissionOptions,
@@ -472,6 +479,38 @@ export function createAgentSubmissionSessionHandler(
 	};
 }
 
+/** Report only the attempt returned by a successful store change. */
+export function emitSubmissionAttemptChanged(
+	previous: AgentSubmission,
+	current: AgentSubmission,
+	operation: SubmissionAttemptChanged['operation'],
+	emit: CoordinatorEventEmitter | undefined,
+	position: SubmissionAttemptChanged['position'] = {
+		lastStreamOffset: null,
+		pendingToolCount: null,
+	},
+): void {
+	if (!current.attemptId) return;
+	// Claims guard queued status, but the row can be claimed and requeued
+	// after it was listed. Keep that stale prior snapshot unknown.
+	const previousApplies =
+		operation === 'replace_submission_attempt' ||
+		previous.attemptCount === current.attemptCount - 1;
+	emit?.({
+		type: 'submission_attempt_changed',
+		submissionId: current.submissionId,
+		kind: current.kind,
+		operation,
+		previous: previousApplies
+			? { attemptId: previous.attemptId ?? null, attemptCount: previous.attemptCount }
+			: null,
+		current: { attemptId: current.attemptId, attemptCount: current.attemptCount },
+		maxAttempts: current.maxAttempts,
+		reason: operation === 'claim_submission' ? 'queued_claim' : 'interrupted_transcript',
+		position,
+	});
+}
+
 /**
  * Shared reconciliation decision tree for an interrupted running submission.
  * Used by both the Cloudflare and Node agent coordinators.
@@ -505,9 +544,10 @@ export async function reconcileInterruptedSubmission(
 	// requeue branches — exhausting either must never discard (or append a
 	// contradictory interruption advisory over) work that already completed.
 	const ctx = createContext(input.submissionId);
-	const state = (await createAgentSubmissionSessionHandler(agent, input, (s) =>
+	const inspection = (await createAgentSubmissionSessionHandler(agent, input, (s) =>
 		s.inspectSubmissionInput(input),
-	)(ctx)) as AgentSubmissionInspection;
+	)(ctx)) as AgentSubmissionInspectionSnapshot;
+	const { state } = inspection;
 	if (state === 'completed') {
 		await settleJoinedSubmissions(
 			submissions,
@@ -658,6 +698,13 @@ export async function reconcileInterruptedSubmission(
 			lease,
 		);
 		if (!replacement?.attemptId) return undefined;
+		emitSubmissionAttemptChanged(
+			submission,
+			replacement,
+			'replace_submission_attempt',
+			emitCoordinatorEvent,
+			inspection.position,
+		);
 		return replacement;
 	}
 

--- a/packages/runtime/src/runtime/submission-attempt-events.test.ts
+++ b/packages/runtime/src/runtime/submission-attempt-events.test.ts
@@ -1,0 +1,352 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createCallHandle } from '../abort.ts';
+import type { AgentSubmission } from '../agent-execution-store.ts';
+import { createFlueContext } from '../client.ts';
+import { createCloudflareAgentRuntime } from '../cloudflare/agent-coordinator.ts';
+import type { Harness } from '../harness.ts';
+import { observe } from '../index.ts';
+import { createNodeAgentCoordinator } from '../node/agent-coordinator.ts';
+import { sqlite } from '../node/agent-execution-store.ts';
+import type { FlueObservation } from '../types.ts';
+import type { AgentSubmissionInput, AgentSubmissionSession } from './agent-submissions.ts';
+import { drainGlobalEventDeliveries } from './events.ts';
+import { generateAttemptId, generateSubmissionId } from './ids.ts';
+
+type Platform = 'cloudflare' | 'node';
+type AttemptEvent = Extract<FlueObservation, { type: 'submission_attempt_changed' }>;
+const cleanups: Array<() => void | Promise<void>> = [];
+
+afterEach(async () => {
+	while (cleanups.length) await cleanups.pop()?.();
+	await drainGlobalEventDeliveries();
+	vi.restoreAllMocks();
+});
+
+async function setup(platform: Platform, kind: 'direct' | 'dispatch' = 'direct') {
+	const persistence = sqlite();
+	await persistence.migrate?.();
+	const stores = await persistence.connect();
+	cleanups.push(() => persistence.close?.());
+	const store = stores.submissionStore;
+	const input: AgentSubmissionInput = {
+		kind,
+		submissionId: generateSubmissionId(),
+		agent: 'AttemptAgent',
+		id: 'attempt-events',
+		message: { kind: 'user', body: 'Test input' },
+		acceptedAt: new Date().toISOString(),
+	};
+	if (kind === 'direct') await store.admitDirect(input);
+	else await store.admitDispatch(input);
+	await store.markSubmissionCanonicalReady(input.submissionId);
+	const order: string[] = [];
+	const changes: AttemptEvent[] = [];
+	const scopes: Array<{ id: string; req: Request | undefined }> = [];
+	cleanups.push(
+		observe((event, ctx) => {
+			if (event.type !== 'submission_attempt_changed') return;
+			order.push('event');
+			changes.push(event);
+			scopes.push({ id: ctx.id, req: ctx.req });
+		}),
+	);
+	const returned: AgentSubmission[] = [];
+	const getSubmission = store.getSubmission.bind(store);
+	vi.spyOn(store, 'getSubmission').mockImplementation((...args) => {
+		order.push('submission_read');
+		return getSubmission(...args);
+	});
+	const claim = store.claimSubmission.bind(store);
+	const replace = store.replaceSubmissionAttempt.bind(store);
+	vi.spyOn(store, 'claimSubmission').mockImplementation(async (...args) => {
+		const row = await claim(...args);
+		if (row) {
+			returned.push(row);
+			order.push('claim_return');
+		}
+		return row;
+	});
+	vi.spyOn(store, 'replaceSubmissionAttempt').mockImplementation(async (...args) => {
+		const row = await replace(...args);
+		if (row) {
+			returned.push(row);
+			order.push('replace_return');
+		}
+		return row;
+	});
+	// Keep the coordinators, SQL guards, and observe() real. The session
+	// driver completes locally, without a model or a provider request.
+	const session: AgentSubmissionSession = {
+		conversationId: 'test-conversation',
+		inspectSubmissionInput: vi.fn(() => ({
+			state: 'interrupted' as const,
+			position: { lastStreamOffset: '41', pendingToolCount: null },
+		})),
+		processSubmissionInput: () =>
+			createCallHandle(undefined, async () => {
+				order.push('process');
+			}),
+		recordSubmissionTerminal: async () => [],
+	};
+	const createContext = () => {
+		order.push('context');
+		const ctx = createFlueContext({
+			id: input.id,
+			agentName: input.agent,
+			submissionId: input.submissionId,
+			env: {},
+			agentConfig: { resolveModel: () => undefined },
+		});
+		ctx.initializeRootHarness = async () =>
+			({ session: async () => session }) as unknown as Harness;
+		return ctx;
+	};
+	const agents = [{ name: input.agent, agent: () => 'Test agent' }];
+	let wake: () => Promise<void>;
+	let idle: () => Promise<void>;
+	if (platform === 'cloudflare') {
+		const fibers: Promise<void>[] = [];
+		const deliveries: Promise<unknown>[] = [];
+		const runtime = createCloudflareAgentRuntime({
+			agents,
+			createContext,
+			runWithInstanceContext: (_instance, _agentName, callback) => callback(),
+		});
+		const instance = {
+			name: input.id,
+			env: {},
+			ctx: {
+				id: { toString: () => 'test-object' },
+				storage: {},
+				waitUntil: (promise: Promise<unknown>) => deliveries.push(promise),
+			},
+			schedule: async () => undefined,
+			runFiber: (
+				_name: string,
+				callback: (ctx: { stash(snapshot: unknown): void }) => Promise<void>,
+			) => {
+				order.push('fiber');
+				const fiber = callback({ stash: () => {} });
+				fibers.push(fiber);
+				return fiber;
+			},
+		};
+		runtime.attach(instance, { agentName: input.agent, ...stores });
+		wake = () => runtime.drainSubmissions(instance);
+		idle = async () => {
+			await Promise.all(fibers);
+			await Promise.all(deliveries);
+		};
+		cleanups.push(idle);
+	} else {
+		const coordinator = createNodeAgentCoordinator({
+			submissions: store,
+			agents,
+			createContext,
+		});
+		wake = () => coordinator.reconcileSubmissions();
+		idle = () => coordinator.waitForIdle();
+		cleanups.push(() => coordinator.shutdown());
+	}
+	const startInterrupted = async () => {
+		const row = await claim({
+			submissionId: input.submissionId,
+			attemptId: generateAttemptId(),
+			ownerId: 'previous-process',
+			leaseExpiresAt: Date.now() - 60_000,
+		});
+		expect(row?.attemptId).toBeDefined();
+		if (!row?.attemptId) throw new Error('Test claim did not return an attempt');
+		return { ...row, attemptId: row.attemptId };
+	};
+	return {
+		store,
+		input,
+		order,
+		changes,
+		scopes,
+		returned,
+		session,
+		claim,
+		replace,
+		wake,
+		idle,
+		startInterrupted,
+	};
+}
+
+describe.each<Platform>(['cloudflare', 'node'])('%s committed attempt events', (platform) => {
+	it.each(['direct', 'dispatch'] as const)(
+		'reports a returned %s claim before execution',
+		async (kind) => {
+			const test = await setup(platform, kind);
+			await Promise.all([test.wake(), test.wake()]);
+			await test.idle();
+			expect(test.changes).toHaveLength(1);
+			expect(test.scopes).toEqual([{ id: test.input.id, req: undefined }]);
+			const row = test.returned[0];
+			expect(row).toBeDefined();
+			expect(test.changes[0]).toEqual({
+				type: 'submission_attempt_changed',
+				submissionId: row?.submissionId,
+				kind,
+				operation: 'claim_submission',
+				previous: { attemptId: null, attemptCount: 0 },
+				current: { attemptId: row?.attemptId, attemptCount: row?.attemptCount },
+				maxAttempts: row?.maxAttempts,
+				reason: 'queued_claim',
+				position: { lastStreamOffset: null, pendingToolCount: null },
+				v: 3,
+				eventIndex: expect.any(Number),
+				timestamp: expect.any(String),
+				agentName: test.input.agent,
+				instanceId: test.input.id,
+			});
+			expect(test.order.slice(0, 3)).toEqual([
+				'claim_return',
+				'event',
+				platform === 'cloudflare' ? 'fiber' : 'submission_read',
+			]);
+			expect(test.order).toContain('process');
+			expect((await test.store.getSubmission(test.input.submissionId))?.status).toBe('settled');
+		},
+	);
+
+	it('keeps the observed count after requeue without inventing a prior ID', async () => {
+		const test = await setup(platform);
+		for (let count = 0; count < 3; count++) {
+			const old = await test.startInterrupted();
+			await test.store.markSubmissionInputApplied(old, {
+				maxAttempts: 7,
+				timeoutAt: Date.now() + 60_000,
+			});
+			await test.store.requeueSubmission(old);
+		}
+		await test.wake();
+		await test.idle();
+		expect(test.changes).toHaveLength(1);
+		expect(test.changes[0]?.previous).toEqual({ attemptId: null, attemptCount: 3 });
+		expect(test.changes[0]?.current.attemptCount).toBe(4);
+		expect(test.changes[0]?.maxAttempts).toBe(10);
+	});
+
+	it('leaves a stale queued snapshot unknown after a competing claim and requeue', async () => {
+		const test = await setup(platform);
+		const list = test.store.listRunnableSubmissions.bind(test.store);
+		vi.spyOn(test.store, 'listRunnableSubmissions').mockImplementationOnce(async () => {
+			const selected = await list();
+			await test.store.requeueSubmission(await test.startInterrupted());
+			return selected;
+		});
+		await test.wake();
+		await test.idle();
+		expect(test.changes).toHaveLength(1);
+		expect(test.changes[0]?.previous).toBeNull();
+		expect(test.changes[0]?.current).toEqual({
+			attemptId: test.returned[0]?.attemptId,
+			attemptCount: 2,
+		});
+	});
+
+	it('emits no change when a competing claim makes the selected row stale', async () => {
+		const test = await setup(platform);
+		const list = test.store.listRunnableSubmissions.bind(test.store);
+		vi.spyOn(test.store, 'listRunnableSubmissions').mockImplementationOnce(async () => {
+			const selected = await list();
+			await test.claim({
+				submissionId: test.input.submissionId,
+				attemptId: generateAttemptId(),
+				ownerId: 'competing-process',
+				leaseExpiresAt: Date.now() + 60_000,
+			});
+			return selected;
+		});
+		await test.wake();
+		await test.idle();
+		expect(test.store.claimSubmission).toHaveBeenCalled();
+		expect(test.returned).toEqual([]);
+		expect(test.changes).toEqual([]);
+		expect(test.order).not.toContain('process');
+	});
+
+	it('reports the guarded replacement once with its current and previous IDs', async () => {
+		const test = await setup(platform);
+		const old = await test.startInterrupted();
+		await Promise.all([test.wake(), test.wake()]);
+		await test.idle();
+		expect(test.changes).toHaveLength(1);
+		const row = test.returned[0];
+		expect(row?.attemptId).not.toBe(old.attemptId);
+		expect(test.changes[0]).toMatchObject({
+			submissionId: old.submissionId,
+			operation: 'replace_submission_attempt',
+			previous: { attemptId: old.attemptId, attemptCount: old.attemptCount },
+			current: { attemptId: row?.attemptId, attemptCount: row?.attemptCount },
+			maxAttempts: row?.maxAttempts,
+			reason: 'interrupted_transcript',
+			position: { lastStreamOffset: '41', pendingToolCount: null },
+		});
+		const committed = test.order.indexOf('replace_return');
+		expect(committed).toBeGreaterThanOrEqual(0);
+		expect(test.order.slice(committed, committed + 3)).toEqual([
+			'replace_return',
+			'event',
+			platform === 'cloudflare' ? 'fiber' : 'submission_read',
+		]);
+		expect(test.order.filter((step) => step === 'process')).toHaveLength(1);
+	});
+
+	it('emits no change for a replacement rejected by the attempt guard', async () => {
+		const test = await setup(platform);
+		await test.startInterrupted();
+		const method = platform === 'cloudflare' ? 'listRunningSubmissions' : 'listExpiredSubmissions';
+		const list = test.store[method].bind(test.store);
+		vi.spyOn(test.store, method).mockImplementationOnce(async () => {
+			const selected = await list();
+			const old = selected[0];
+			if (!old?.attemptId) throw new Error('Test recovery found no running attempt');
+			await test.replace(
+				{ submissionId: old.submissionId, attemptId: old.attemptId },
+				generateAttemptId(),
+				{
+					ownerId: 'competing-process',
+					leaseExpiresAt: Date.now() + 60_000,
+				},
+			);
+			return selected;
+		});
+		await test.wake();
+		await test.idle();
+		expect(test.store.replaceSubmissionAttempt).toHaveBeenCalled();
+		expect(test.returned).toEqual([]);
+		expect(test.changes).toEqual([]);
+		expect(test.order).not.toContain('process');
+	});
+
+	it.each(['claim', 'replacement'])(
+		'contains thrown and rejected observers during a %s',
+		async (operation) => {
+			const failure = new Error('Test observer failure');
+			const logged = vi.spyOn(console, 'error').mockImplementation(() => {});
+			cleanups.push(
+				observe((event) => {
+					if (event.type === 'submission_attempt_changed') throw failure;
+				}),
+			);
+			cleanups.push(
+				observe(async (event) => {
+					if (event.type === 'submission_attempt_changed') throw failure;
+				}),
+			);
+			const test = await setup(platform);
+			if (operation === 'replacement') await test.startInterrupted();
+			await test.wake();
+			await test.idle();
+			await drainGlobalEventDeliveries();
+			expect(test.changes).toHaveLength(1);
+			expect(test.order).toContain('process');
+			expect((await test.store.getSubmission(test.input.submissionId))?.status).toBe('settled');
+			expect(logged.mock.calls.filter(([, error]) => error === failure)).toHaveLength(2);
+		},
+	);
+});

--- a/packages/runtime/src/session-inspection.test.ts
+++ b/packages/runtime/src/session-inspection.test.ts
@@ -1,0 +1,107 @@
+import { expect, it, vi } from 'vitest';
+import { encodeCanonicalId } from './conversation-records.ts';
+import { ConversationRecordWriter } from './conversation-writer.ts';
+import { sqlite } from './node/agent-execution-store.ts';
+import type { AgentSubmissionInput } from './runtime/agent-submissions.ts';
+import { generateAttemptId, generateRecordId, generateSubmissionId } from './runtime/ids.ts';
+import { agentStreamPath } from './runtime/stream-offsets.ts';
+import { Session } from './session.ts';
+
+it('returns the existing inspection offset without another stream read or a guessed tool count', async () => {
+	const persistence = sqlite();
+	await persistence.migrate?.();
+	const stores = await persistence.connect();
+	let session: Session | undefined;
+	try {
+		const writer = await ConversationRecordWriter.create({
+			store: stores.conversationStreamStore,
+			path: agentStreamPath('InspectionAgent', 'test'),
+			identity: { agentName: 'InspectionAgent', instanceId: 'test' },
+			producerId: 'test-producer',
+		});
+		const scope = { conversationId: 'test-conversation', harness: 'default', session: 'default' };
+		await writer.ensureConversation({
+			...scope,
+			kind: 'root',
+			affinityKey: 'test-affinity',
+			createdAt: new Date().toISOString(),
+		});
+		const conversation = await writer.getConversation(scope.conversationId);
+		if (!conversation) throw new Error('Test conversation is missing');
+		session = new Session({
+			name: 'default',
+			conversation,
+			conversationWriter: writer,
+			attachmentStore: stores.attachmentStore,
+			envSlot: { env: undefined, toolFactory: undefined, rediscoverNeeded: false },
+			config: {
+				systemPrompt: '',
+				skills: {},
+				resolveModel: () => undefined,
+				model: {
+					id: 'test-model',
+					name: 'Test model',
+					api: 'openai-completions',
+					provider: 'test',
+					baseUrl: 'https://unused.invalid',
+					reasoning: false,
+					input: ['text'],
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+					contextWindow: 8192,
+					maxTokens: 100,
+				},
+			},
+		});
+		const input: AgentSubmissionInput = {
+			kind: 'direct',
+			submissionId: generateSubmissionId(),
+			agent: 'InspectionAgent',
+			id: 'test',
+			message: { kind: 'user', body: 'Test input' },
+			acceptedAt: new Date().toISOString(),
+		};
+		const read = vi.spyOn(stores.conversationStreamStore, 'read');
+		const getConversation = vi.spyOn(writer, 'getConversation');
+		const initialOffset = writer.offset;
+		expect(await session.inspectSubmissionInput(input)).toEqual({
+			state: 'absent',
+			position: { lastStreamOffset: initialOffset, pendingToolCount: null },
+		});
+		await stores.submissionStore.admitDirect(input);
+		await stores.submissionStore.markSubmissionCanonicalReady(input.submissionId);
+		const attempt = { submissionId: input.submissionId, attemptId: generateAttemptId() };
+		await stores.submissionStore.claimSubmission({
+			...attempt,
+			ownerId: 'test-producer',
+			leaseExpiresAt: Date.now() + 60_000,
+		});
+		const appended = await writer.append(
+			[
+				{
+					...scope,
+					v: 1,
+					id: generateRecordId(),
+					type: 'user_message',
+					timestamp: new Date().toISOString(),
+					submissionId: input.submissionId,
+					attemptId: attempt.attemptId,
+					messageId: `entry_direct_${encodeCanonicalId(input.submissionId)}`,
+					parentId: null,
+					content: [{ type: 'text', text: input.message.body }],
+				},
+			],
+			{ submission: attempt },
+		);
+		expect(appended.offset).not.toBe(initialOffset);
+		expect(await session.inspectSubmissionInput(input)).toEqual({
+			state: 'interrupted',
+			position: { lastStreamOffset: appended.offset, pendingToolCount: null },
+		});
+		expect(getConversation).toHaveBeenCalledTimes(2);
+		expect(read).not.toHaveBeenCalled();
+	} finally {
+		await session?.close();
+		await persistence.close?.();
+		vi.restoreAllMocks();
+	}
+});

--- a/packages/runtime/src/session.ts
+++ b/packages/runtime/src/session.ts
@@ -151,6 +151,7 @@ import {
 import type {
 	AgentSubmissionInput,
 	AgentSubmissionInspection,
+	AgentSubmissionInspectionSnapshot,
 	AgentSubmissionInterruption,
 	AgentSubmissionSession,
 	InterruptedToolCallRef,
@@ -2734,14 +2735,24 @@ export class Session implements FlueSession, AgentSubmissionSession {
 		);
 	}
 
-	async inspectSubmissionInput(input: AgentSubmissionInput): Promise<AgentSubmissionInspection> {
+	async inspectSubmissionInput(
+		input: AgentSubmissionInput,
+	): Promise<AgentSubmissionInspectionSnapshot> {
 		const conversation = await this.conversationWriter.getConversation(this.conversationId);
-		if (!conversation?.entries.has(this.canonicalInputEntryId(input))) return 'absent';
-		return this.inspectCanonicalState(
-			classifyConversationSubmission(conversation, this.canonicalInputEntryId(input), {
-				contextWindow: this.agentLoop.state.model?.contextWindow ?? 0,
-			}),
-		);
+		return {
+			state: !conversation?.entries.has(this.canonicalInputEntryId(input))
+				? 'absent'
+				: this.inspectCanonicalState(
+						classifyConversationSubmission(conversation, this.canonicalInputEntryId(input), {
+							contextWindow: this.agentLoop.state.model?.contextWindow ?? 0,
+						}),
+					),
+			position: {
+				lastStreamOffset: this.conversationWriter.offset,
+				// This inspection does not count unresolved tool calls.
+				pendingToolCount: null,
+			},
+		};
 	}
 
 	processSubmissionInput(

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -1281,6 +1281,23 @@ type FlueEventVariant =
 			kind: 'dispatch' | 'direct';
 	  }
 	| {
+			/** A guarded claim or replacement returned a new attempt, before
+			 *  execution starts. A process can stop after the store commits and
+			 *  before delivery; this live event has no replay guarantee. */
+			type: 'submission_attempt_changed';
+			submissionId: string;
+			kind: 'dispatch' | 'direct';
+			operation: 'claim_submission' | 'replace_submission_attempt';
+			/** The observed prior row, or null when a queued snapshot is stale. */
+			previous: { attemptId: string | null; attemptCount: number } | null;
+			/** Values copied from the row returned by the store. */
+			current: { attemptId: string; attemptCount: number };
+			maxAttempts: number;
+			reason: 'queued_claim' | 'interrupted_transcript';
+			/** The existing recovery inspection; null fields mean unknown. */
+			position: { lastStreamOffset: string | null; pendingToolCount: number | null };
+	  }
+	| {
 			/** An attempt started processing a claimed submission. Emitted on
 			 *  EVERY attempt — recovery replacements re-emit it with the
 			 *  incremented `attemptCount` — which is what lets an observer


### PR DESCRIPTION
Observers cannot see the committed submission attempt until execution starts. This adds `submission_attempt_changed` to `observe()` immediately after a guarded claim or replacement returns, before execution starts.

- Cloudflare and Node use the existing contained coordinator emitter.
- Current IDs, count, kind, and budget come from the returned row. The prior snapshot stays unknown when a queued selection is stale.
- Rejected stale changes emit nothing. The existing recovery inspection supplies the stream offset without another query. Its pending-tool count stays unknown.
- Observer failures do not change execution. A process can stop between the store commit and event delivery; no replay or outbox is added.

Validation: 19 runtime regressions pass with real SQL claims and replacements on both coordinators. They cover stale selections, duplicate wakes, prior/current IDs, observer failures, and ordering before execution. The Session regression checks the existing offset without another stream read. All 59 workspace build tasks and all 109 type-check/build tasks pass. The changed files pass Biome with five existing warnings outside the changed lines.

The full `pnpm check` stops at Knip: 48 unused dependency listings, 29 unused exports, and two unused exported types. Upstream main `1ae1c85d` reproduces the same listings. The full `pnpm test` stops at `@flue/twilio` because that package has no test files; other existing packages report the same limit. The runtime suite passes when run directly.

GitHub reports no required checks, status checks, or automated reviews. Upstream main has no PR CI workflow. The repository-wide checks are not green; these limits remain explicit.

The full fixer staff review covers correctness, design, privacy, tests, repository checks, and reader compatibility. No blocker, major, minor, or nit remains in this change. The review fixes the test lease, write permission, type, and observer assertion gaps. It also removes unrelated formatting changes. The live delivery gap remains.

RUN-7631. This adds a live event, with no durable record or storage format change. The SQL guards, attempt budgets, scheduling, execution, recovery, and settlement stay as they are. Package publication and Runner adoption are separate work. This PR has no Runner deployment effect.
