### PR TITLE
fix(runtime): clear verified abandoned messages before new input

### DIFF
--- a/apps/docs/src/content/docs/reference/data-persistence-api.md
+++ b/apps/docs/src/content/docs/reference/data-persistence-api.md
@@ -143,6 +143,7 @@ Canonical per-agent-instance conversation streams: ordered, append-only batches 
 
 ```ts
 interface ConversationStreamStore {
+  readonly supportsAbandonedMessageCleanup?: true;
   createStream(path: string, identity: ConversationStreamIdentity): Promise<void>;
   acquireProducer(path: string, producerId: string): Promise<ConversationProducerClaim>;
   append(input: {
@@ -152,6 +153,7 @@ interface ConversationStreamStore {
     incarnation: string;
     producerSequence: number;
     submission?: { submissionId: string; attemptId: string };
+    abandonedMessage?: AbandonedMessageAuthorization;
     records: readonly ConversationRecord[];
   }): Promise<{ offset: string }>;
   read(
@@ -170,13 +172,56 @@ interface ConversationStreamStore {
 
 - `createStream` — create the stream if absent, minting a fresh incarnation id. Racing creates with the same identity both succeed; a conflicting identity for an existing path throws.
 - `acquireProducer` — take exclusive producership: increments the producer epoch, resets the producer sequence, and returns a claim carrying the epoch, incarnation, and current head offset. Acquisition fences every prior producer.
-- `append` — append one batch of records under one offset. Requires a current producer id, epoch, and incarnation, and the next expected `producerSequence`. An exact retry of an already-appended sequence returns the original offset; a conflicting retry throws. Records carrying `submissionId`/`attemptId` require a `submission` authorization that owns them. Every record in the batch persists together, all-or-nothing — a partial write corrupts the conversation graph.
+- `append` — append one batch of records under one offset. Require a current producer ID, epoch, incarnation, and the next `producerSequence`. An exact retry returns the original offset; a conflicting retry throws. Ordinary records with `submissionId` or `attemptId` require matching `submission` authorization. The cleanup exception is described below. Persist every record in the batch together; a partial write corrupts the conversation graph.
 - `read` — batches strictly after `options.offset` (default `'-1'`, the start). The sentinel `'now'` returns no batches and the current head as `nextOffset`. `limit` is clamped between `DEFAULT_READ_LIMIT` (`100`) and `MAX_READ_LIMIT` (`1000`). An offset beyond the head throws; an unknown path returns an empty, up-to-date result.
 - `getMeta` — the stream's identity, incarnation, head offset, and producer state, or `null` for an unknown path.
 - `subscribe` — register a process-local change listener for a path; returns an unsubscribe function. Notification is best-effort in-process fan-out, not a durable or cross-process signal.
 - `putFoldCheckpoint` / `getFoldCheckpoint` — optional fold-checkpoint capability: one durable serialized-fold snapshot per path, superseded on each write, so loads fold only the suffix appended since it instead of replaying the stream from the origin. A checkpoint is a cache over the log, never authoritative — the runtime validates its format version, incarnation, and offset on load and silently rebuilds by replay when anything mismatches. Adapters without the pair stay fully functional; the runtime degrades to full replay and warns once per path. Implementations must be torn-write safe: a partially persisted checkpoint must read back as absent or fail the read, never as a plausible blob. `getFoldCheckpoint` with `atOrBefore` returns the checkpoint only when its offset is at or before the bound.
 
 Offsets are opaque strings ordered by the stream; `formatOffset` and `parseOffset` convert between offset strings and integer sequence numbers. `defineSqlConversationStreamStore(dialect: SqlConversationDialect)` builds a complete `ConversationStreamStore` over an async SQL backend — the Postgres, libSQL, and MySQL adapters share one fence implementation and differ only in dialect constants. `InMemoryConversationStreamStore` and `StreamListenerRegistry` are exported as reference building blocks.
+
+### Abandoned assistant messages
+
+Before processing new input, the writer can clear an open assistant message behind the active tail.
+The default conversation must contain that message.
+Its stored submission must be an earlier, settled, unjoined dispatch in the same agent instance and default session.
+The stored sequence and settlement time must match the values selected by the writer.
+The final attempt can differ from the attempt that opened the message.
+
+The writer drains pending records before it selects messages.
+It then appends one `assistant_message_abandoned` record for each selected message and waits before processing input.
+The record has a stable ID from the conversation, submission, and message IDs.
+It records the present cleanup time, without an old outcome or attempt ID.
+It removes only that message's open state.
+Completed entries, raw records, tool outcomes, and the active tail remain available.
+No tool runs, and the old submission row stays unchanged.
+
+Adapters must set `supportsAbandonedMessageCleanup: true` only when they implement the new append checks.
+The `abandonedMessage` option supplies the selected terminal row fields and the current successor attempt.
+Parse it with `parseAbandonedMessageBatch` and check the stored rows with `checkAbandonedMessageRows`.
+Redis implements the stored-row checks in its append script.
+Check both rows within the record append transaction.
+Keep the producer epoch, incarnation, sequence, and ordinary attempt checks.
+Reject mixed batches, ordinary attempt options, missing rows, changed terminal fields, and foreign sessions.
+An exact storage retry must still pass the cleanup checks.
+A fresh writer skips a message whose cleanup record already removed its open state.
+
+SQLite, libSQL, Postgres, MySQL, MongoDB, and Redis implement this capability.
+The transient memory store cannot transact with submission storage and refuses cleanup.
+Older custom adapters also refuse cleanup until they implement and enable the capability.
+Read failures, append failures, and failed checks prevent the new input from running.
+
+**Stop old runtime readers before starting this version against a shared store.**
+Do not use a rolling deployment that leaves old raw-record readers active.
+The cleanup record uses record version 2; existing records keep version 1.
+Older runtime readers reject version 2 instead of silently keeping the old open message.
+The fold checkpoint format increases from 2 to 3.
+Both reader versions discard an unsupported checkpoint and replay records.
+New readers replay existing version 1 records and the new cleanup record.
+Old readers cannot read past the first cleanup record, including after a rollback.
+This change does not change the database format stamp or reset stored data.
+Live clients receive the existing `conversation-reset` chunk with the corrected snapshot.
+Custom raw-record readers must implement the new record before they consume a cleaned stream.
 
 ## `AttachmentStore`
 

--- a/packages/libsql/src/conversation-store.test.ts
+++ b/packages/libsql/src/conversation-store.test.ts
@@ -1,0 +1,58 @@
+import { defineConversationStreamStoreContractTests } from '@flue/runtime/test-utils/conversation-stream';
+import { createClient, type InValue } from '@libsql/client';
+import { type LibsqlQuery, libsql } from './libsql-adapter.ts';
+
+const clients: ReturnType<typeof createClient>[] = [];
+const directories: string[] = [];
+defineConversationStreamStoreContractTests('libSQL conversation store', {
+	async create() {
+		const directory = mkdtempSync(join(tmpdir(), 'flue-cleanup-test-'));
+		directories.push(directory);
+		const client = createClient({ url: `file:${join(directory, 'store.sqlite')}` });
+		clients.push(client);
+		let tail: Promise<unknown> = Promise.resolve();
+		const serialize = <T>(work: () => Promise<T>) => {
+			const next = tail.then(work, work);
+			tail = next.catch(() => undefined);
+			return next;
+		};
+		const query: LibsqlQuery = (sql, args = []) =>
+			serialize(async () => (await client.execute({ sql, args: args as InValue[] })).rows);
+		const adapter = libsql({
+			query,
+			transaction: (fn) =>
+				serialize(async () => {
+					const tx = await client.transaction('write');
+					try {
+						const result = await fn({
+							query: async (sql, args = []) =>
+								(await tx.execute({ sql, args: args as InValue[] })).rows,
+						});
+						await tx.commit();
+						return result;
+					} catch (error) {
+						await tx.rollback();
+						throw error;
+					} finally {
+						tx.close();
+					}
+				}),
+			close: () => client.close(),
+		});
+		await adapter.migrate?.();
+		const connection = await adapter.connect();
+		return {
+			stream: connection.conversationStreamStore,
+			submissionStore: connection.submissionStore,
+		};
+	},
+	cleanup() {
+		for (const client of clients.splice(0)) client.close();
+		for (const directory of directories.splice(0))
+			rmSync(directory, { recursive: true, force: true });
+	},
+});
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';

--- a/packages/libsql/vitest.config.ts
+++ b/packages/libsql/vitest.config.ts
@@ -1,0 +1,3 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({ test: { environment: 'node' } });

--- a/packages/mongodb/src/conversation-store.test.ts
+++ b/packages/mongodb/src/conversation-store.test.ts
@@ -1,0 +1,124 @@
+import { defineConversationStreamStoreContractTests } from '@flue/runtime/test-utils/conversation-stream';
+import { type ClientSession, MongoClient } from 'mongodb';
+import { describe } from 'vitest';
+import { mongodb } from './mongodb-adapter.ts';
+import {
+	type MongoDocument,
+	type MongoOperations,
+	type MongoRunner,
+	runMongoTransactionWithRetry,
+} from './mongodb-runner.ts';
+
+const url = process.env.FLUE_TEST_MONGODB_URL;
+const clients: MongoClient[] = [];
+let sequence = 0;
+
+describe.skipIf(!url)('MongoDB integration', () => {
+	defineConversationStreamStoreContractTests('MongoDB conversation store', {
+		async create() {
+			if (!url) throw new Error('FLUE_TEST_MONGODB_URL is required.');
+			const client = new MongoClient(url);
+			clients.push(client);
+			await client.connect();
+			const db = client.db(`flue_cleanup_${process.pid}_${sequence++}`);
+			const operations = (session?: ClientSession): MongoOperations => ({
+				collection(name) {
+					const collection = db.collection<MongoDocument>(name);
+					return {
+						findOne: (filter, options) => collection.findOne(filter, { ...options, session }),
+						find: (filter = {}, options) =>
+							collection.find(filter, { ...options, session }).toArray(),
+						insertOne: (document) => collection.insertOne(document, { session }),
+						insertMany: (documents) => collection.insertMany(documents, { session }),
+						updateOne: (filter, update, options) =>
+							collection.updateOne(filter, update, { ...options, session }),
+						updateMany: (filter, update) => collection.updateMany(filter, update, { session }),
+						findOneAndUpdate: (filter, update, options) =>
+							collection.findOneAndUpdate(filter, update, { ...options, session }),
+						deleteOne: (filter) => collection.deleteOne(filter, { session }),
+						deleteMany: (filter) => collection.deleteMany(filter, { session }),
+					};
+				},
+			});
+			const runner: MongoRunner = {
+				...operations(),
+				transaction: (fn) =>
+					runMongoTransactionWithRetry(
+						() => {
+							const session = client.startSession();
+							return {
+								start: () =>
+									session.startTransaction({
+										readConcern: { level: 'snapshot' },
+										writeConcern: { w: 'majority' },
+									}),
+								commit: () => session.commitTransaction(),
+								abort: () => session.abortTransaction(),
+								end: () => session.endSession(),
+								operations: operations(session),
+							};
+						},
+						fn,
+						{
+							hasErrorLabel: (error, label) =>
+								typeof error === 'object' &&
+								error !== null &&
+								'hasErrorLabel' in error &&
+								typeof error.hasErrorLabel === 'function' &&
+								error.hasErrorLabel(label),
+						},
+					),
+				async topology() {
+					const hello = await db.admin().command({ hello: 1 });
+					return {
+						kind: hello.setName ? 'replica_set' : 'standalone',
+						transactions: Boolean(hello.setName),
+					};
+				},
+				async ensureCollection(spec) {
+					if (!(await db.listCollections({ name: spec.name }).hasNext())) {
+						await db.createCollection(spec.name, {
+							validator: spec.validator,
+							validationLevel: spec.validationLevel,
+							validationAction: spec.validationAction,
+						});
+					}
+					for (const { key, ...options } of spec.indexes)
+						await db.collection(spec.name).createIndex(key, options);
+				},
+				async inspectCollection(name) {
+					const info = await db.listCollections({ name }).next();
+					if (!info || !('options' in info)) return null;
+					const indexes = (await db.collection(name).listIndexes().toArray()).filter(
+						(index) => index.name !== '_id_',
+					);
+					return {
+						validator: info.options?.validator ?? {},
+						validationLevel: info.options?.validationLevel ?? 'strict',
+						validationAction: info.options?.validationAction ?? 'error',
+						indexes: indexes.map((index) => ({
+							name: String(index.name),
+							key: index.key,
+							...(index.unique ? { unique: true } : {}),
+							...(index.partialFilterExpression
+								? { partialFilterExpression: index.partialFilterExpression }
+								: {}),
+							...(index.collation ? { collation: { locale: index.collation.locale } } : {}),
+						})),
+					};
+				},
+				close: () => client.close(),
+			};
+			const adapter = mongodb(runner);
+			await adapter.migrate?.();
+			const connection = await adapter.connect();
+			return {
+				stream: connection.conversationStreamStore,
+				submissionStore: connection.submissionStore,
+			};
+		},
+		async cleanup() {
+			for (const client of clients.splice(0)) await client.close();
+		},
+	});
+});

--- a/packages/mongodb/src/conversation-store.ts
+++ b/packages/mongodb/src/conversation-store.ts
@@ -1,4 +1,5 @@
 import type {
+	AbandonedMessageAuthorization,
 	ConversationFoldCheckpoint,
 	ConversationRecord,
 	ConversationStreamIdentity,
@@ -8,10 +9,12 @@ import type {
 } from '@flue/runtime/adapter';
 import {
 	ConversationStreamStoreError,
+	checkAbandonedMessageRows,
 	clampLimit,
 	DEFAULT_READ_LIMIT,
 	formatOffset,
 	MAX_READ_LIMIT,
+	parseAbandonedMessageBatch,
 	parseOffset,
 	parseSessionStorageKey,
 	StreamListenerRegistry,
@@ -21,6 +24,7 @@ import type { MongoOperations, MongoRunner } from './mongodb-runner.ts';
 import { collectionName } from './schema.ts';
 
 export class MongoConversationStreamStore implements ConversationStreamStore {
+	readonly supportsAbandonedMessageCleanup = true;
 	private listeners = new StreamListenerRegistry();
 
 	constructor(
@@ -83,11 +87,18 @@ export class MongoConversationStreamStore implements ConversationStreamStore {
 		incarnation: string;
 		producerSequence: number;
 		submission?: { submissionId: string; attemptId: string };
+		abandonedMessage?: AbandonedMessageAuthorization;
 		records: readonly ConversationRecord[];
 	}): Promise<{ offset: string }> {
 		if (input.records.length === 0)
 			throw failure('append', input.path, 'A canonical batch cannot be empty.');
 		const data = JSON.stringify(input.records);
+		const cleanup = parseAbandonedMessageBatch(
+			input.records,
+			input.abandonedMessage,
+			input.submission,
+		);
+		if (!cleanup.ok) throw failure('append', input.path, cleanup.reason);
 		if (data.length > MAX_BATCH_DATA_LENGTH) {
 			throw failure('append', input.path, oversizedBatchReason(data.length, input.records));
 		}
@@ -101,6 +112,18 @@ export class MongoConversationStreamStore implements ConversationStreamStore {
 				meta.incarnation !== input.incarnation
 			)
 				throw failure('append', input.path, 'Producer ownership is stale.');
+			if (cleanup.value) {
+				const authorization = cleanup.value.authorization;
+				const submissions = tx.collection(collectionName(this.prefix, 'submissions'));
+				const target = await submissions.findOne({
+					submissionId: authorization.target.submissionId,
+				});
+				const before = await submissions.findOne({
+					submissionId: authorization.before.submissionId,
+				});
+				const checked = checkAbandonedMessageRows(authorization, target, before, meta.identity);
+				if (!checked.ok) throw failure('append', input.path, checked.reason);
+			}
 			const batches = tx.collection(collectionName(this.prefix, 'conversation_batches'));
 			const retry = await batches.findOne({
 				path: input.path,
@@ -119,14 +142,31 @@ export class MongoConversationStreamStore implements ConversationStreamStore {
 			}
 			if (Number(meta.nextProducerSequence) !== input.producerSequence)
 				throw failure('append', input.path, 'Producer sequence is not the next expected value.');
-			await assertSubmissionAuthorization(
-				tx,
-				this.prefix,
-				input.path,
-				meta.identity as ConversationStreamIdentity,
-				input.submission,
-				input.records,
-			);
+			if (!cleanup.value) {
+				await assertSubmissionAuthorization(
+					tx,
+					this.prefix,
+					input.path,
+					meta.identity as ConversationStreamIdentity,
+					input.submission,
+					input.records,
+				);
+			}
+			if (cleanup.value) {
+				const authorization = cleanup.value.authorization;
+				const submissions = tx.collection(collectionName(this.prefix, 'submissions'));
+				// Settled targets have no legal transition. Fence the running successor against replacement.
+				const fenced = await submissions.updateOne(
+					{
+						submissionId: authorization.before.submissionId,
+						attemptId: authorization.before.attemptId,
+						status: 'running',
+					},
+					{ $inc: { conversationWriteRevision: 1 } },
+				);
+				if (fenced.modifiedCount !== 1)
+					throw failure('append', input.path, 'Cleanup successor changed during append.');
+			}
 			const offset = Number(meta.nextOffset);
 			await batches.insertOne({
 				_id: `${input.path}:${offset}`,

--- a/packages/mongodb/vitest.config.ts
+++ b/packages/mongodb/vitest.config.ts
@@ -1,0 +1,3 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({ test: { environment: 'node', testTimeout: 15_000 } });

--- a/packages/redis/src/conversation-scripts.ts
+++ b/packages/redis/src/conversation-scripts.ts
@@ -23,6 +23,25 @@ return {'acquired', tostring(epoch), tostring(nextOffset), incarnation}
 export const appendConversationScript = `
 if redis.call('EXISTS', KEYS[1]) == 0 then return {'missing'} end
 if redis.call('HGET', KEYS[1], 'producerId') ~= ARGV[1] or redis.call('HGET', KEYS[1], 'producerEpoch') ~= ARGV[2] or redis.call('HGET', KEYS[1], 'incarnation') ~= ARGV[3] then return {'stale'} end
+local batch = cjson.decode(ARGV[5])
+if ARGV[10] and ARGV[10] ~= '' then
+  local authorization = cjson.decode(ARGV[10])
+  local old = authorization.target
+  local before = authorization.before
+  local sessionKey = redis.call('HGET', KEYS[6], 'sessionKey')
+  local oldSequence = tonumber(redis.call('HGET', KEYS[6], 'sequence'))
+  local nextSequence = tonumber(redis.call('HGET', KEYS[5], 'sequence'))
+  local settledAt = tonumber(redis.call('HGET', KEYS[6], 'settledAt'))
+  local joinedInto = redis.call('HGET', KEYS[6], 'joinedInto')
+  if #batch ~= 1 or batch[1].type ~= 'assistant_message_abandoned' or batch[1].v ~= 2 or batch[1].attemptId ~= nil or batch[1].submissionId ~= old.submissionId or ARGV[6] ~= '' then return {'cleanup'} end
+  if redis.call('HGET', KEYS[6], 'submissionId') ~= old.submissionId or redis.call('HGET', KEYS[6], 'kind') ~= 'dispatch' or redis.call('HGET', KEYS[6], 'status') ~= 'settled' or (joinedInto and joinedInto ~= '') or not settledAt or settledAt ~= old.settledAt or sessionKey ~= old.sessionKey or oldSequence ~= old.sequence then return {'cleanup'} end
+  if redis.call('HGET', KEYS[5], 'submissionId') ~= before.submissionId or redis.call('HGET', KEYS[5], 'status') ~= 'running' or redis.call('HGET', KEYS[5], 'attemptId') ~= before.attemptId or redis.call('HGET', KEYS[5], 'sessionKey') ~= sessionKey then return {'cleanup'} end
+  if not oldSequence or not nextSequence or oldSequence < 1 or oldSequence >= nextSequence or nextSequence % 1 ~= 0 or nextSequence > 9007199254740991 then return {'cleanup'} end
+  if not sessionKey or string.sub(sessionKey, 1, 14) ~= 'agent-session:' then return {'cleanup'} end
+  local ok, session = pcall(cjson.decode, string.sub(sessionKey, 15))
+  local stream = cjson.decode(redis.call('HGET', KEYS[1], 'identity'))
+  if not ok or type(session) ~= 'table' or #session ~= 4 or session[1] ~= stream.agentName or session[2] ~= stream.instanceId or session[3] ~= 'default' or session[4] ~= 'default' then return {'cleanup'} end
+end
 local retry = redis.call('HGET', KEYS[4], ARGV[2] .. ':' .. ARGV[4])
 if retry then
   local stored = cjson.decode(retry)
@@ -32,7 +51,6 @@ if retry then
 end
 if tonumber(redis.call('HGET', KEYS[1], 'nextProducerSequence') or '0') ~= tonumber(ARGV[4]) then return {'sequence'} end
 local seq = tonumber(redis.call('HGET', KEYS[1], 'nextOffset') or '0')
-local batch = cjson.decode(ARGV[5])
 if ARGV[6] ~= '' then
   for i = 6, #KEYS do
     local delivery = redis.call('HGET', KEYS[i], 'status')

--- a/packages/redis/src/conversation-store.test.ts
+++ b/packages/redis/src/conversation-store.test.ts
@@ -1,0 +1,38 @@
+import { defineConversationStreamStoreContractTests } from '@flue/runtime/test-utils/conversation-stream';
+import { createClient } from 'redis';
+import { describe } from 'vitest';
+import { redis } from './redis-adapter.ts';
+
+const url = process.env.FLUE_TEST_REDIS_URL;
+let sequence = 0;
+const closeClients: Array<() => Promise<void>> = [];
+
+describe.skipIf(!url)('Redis integration', () => {
+	defineConversationStreamStoreContractTests('Redis conversation store', {
+		async create() {
+			const client = createClient({ url });
+			closeClients.push(async () => {
+				if (client.isOpen) await client.close();
+			});
+			await client.connect();
+			const adapter = redis(
+				{
+					command: (command, args = []) => client.sendCommand([command, ...args.map(String)]),
+					eval: (script, keys, args = []) =>
+						client.eval(script, { keys, arguments: args.map(String) }),
+					close: () => client.close(),
+				},
+				{ keyPrefix: `flue-test-cleanup-${process.pid}-${sequence++}` },
+			);
+			await adapter.migrate?.();
+			const connection = await adapter.connect();
+			return {
+				stream: connection.conversationStreamStore,
+				submissionStore: connection.submissionStore,
+			};
+		},
+		async cleanup() {
+			for (const close of closeClients.splice(0)) await close();
+		},
+	});
+});

--- a/packages/redis/src/conversation-store.ts
+++ b/packages/redis/src/conversation-store.ts
@@ -1,4 +1,5 @@
 import type {
+	AbandonedMessageAuthorization,
 	ConversationFoldCheckpoint,
 	ConversationRecord,
 	ConversationStreamIdentity,
@@ -12,6 +13,7 @@ import {
 	DEFAULT_READ_LIMIT,
 	formatOffset,
 	MAX_READ_LIMIT,
+	parseAbandonedMessageBatch,
 	parseOffset,
 	StreamListenerRegistry,
 } from '@flue/runtime/adapter';
@@ -56,6 +58,7 @@ function integer(value: string | undefined): number {
 }
 
 export class RedisConversationStreamStore implements ConversationStreamStore {
+	readonly supportsAbandonedMessageCleanup = true;
 	private listeners = new StreamListenerRegistry();
 
 	constructor(
@@ -99,14 +102,21 @@ export class RedisConversationStreamStore implements ConversationStreamStore {
 		incarnation: string;
 		producerSequence: number;
 		submission?: { submissionId: string; attemptId: string };
+		abandonedMessage?: AbandonedMessageAuthorization;
 		records: readonly ConversationRecord[];
 	}): Promise<{ offset: string }> {
 		if (input.records.length === 0)
 			throw failure('append', input.path, 'A canonical batch cannot be empty.');
+		const cleanup = parseAbandonedMessageBatch(
+			input.records,
+			input.abandonedMessage,
+			input.submission,
+		);
+		if (!cleanup.ok) throw failure('append', input.path, cleanup.reason);
 		const owned = input.records.filter(
 			(record) => record.submissionId !== undefined || record.attemptId !== undefined,
 		);
-		if (!input.submission && owned.length > 0)
+		if (!input.submission && !cleanup.value && owned.length > 0)
 			throw failure(
 				'append',
 				input.path,
@@ -143,9 +153,11 @@ export class RedisConversationStreamStore implements ConversationStreamStore {
 		const first = input.records[0];
 		if (!first) throw failure('append', input.path, 'A canonical batch cannot be empty.');
 		const expectedIdentity = meta.identity;
-		const submissionKey = input.submission
-			? this.keys.submission(input.submission.submissionId)
-			: this.keys.meta();
+		const submissionKey = cleanup.value
+			? this.keys.submission(cleanup.value.authorization.before.submissionId)
+			: input.submission
+				? this.keys.submission(input.submission.submissionId)
+				: this.keys.meta();
 		const result = strings(
 			await this.runner.eval(
 				appendConversationScript,
@@ -155,6 +167,9 @@ export class RedisConversationStreamStore implements ConversationStreamStore {
 					this.keys.conversationOrder(input.path),
 					this.keys.conversationRetries(input.path),
 					submissionKey,
+					...(cleanup.value
+						? [this.keys.submission(cleanup.value.authorization.target.submissionId)]
+						: []),
 					...joinedDeliveryIds.map((id) => this.keys.submission(id)),
 				],
 				[
@@ -167,6 +182,7 @@ export class RedisConversationStreamStore implements ConversationStreamStore {
 					input.submission?.attemptId ?? '',
 					expectedIdentity.instanceId,
 					expectedIdentity.agentName,
+					cleanup.value ? JSON.stringify(cleanup.value.authorization) : '',
 				],
 			),
 		);
@@ -279,6 +295,8 @@ export class RedisConversationStreamStore implements ConversationStreamStore {
 }
 
 function appendReason(code: string | undefined): string {
+	if (code === 'cleanup')
+		return 'Abandoned message stored evidence is missing, changed, or outside this session.';
 	if (code === 'missing') return 'Stream does not exist.';
 	if (code === 'stale') return 'Producer ownership is stale.';
 	if (code === 'conflict') return 'Producer sequence has conflicting content.';

--- a/packages/redis/vitest.config.ts
+++ b/packages/redis/vitest.config.ts
@@ -1,0 +1,3 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({ test: { environment: 'node' } });

--- a/packages/runtime/src/abandoned-message.test.ts
+++ b/packages/runtime/src/abandoned-message.test.ts
@@ -1,0 +1,478 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { abandonedMessageRecordId } from './abandoned-message.ts';
+import type { AgentSubmissionStore } from './agent-execution-store.ts';
+import { createFlueContext } from './client.ts';
+import { encodeReducedInstanceState } from './conversation-fold-checkpoint.ts';
+import {
+	projectAgentConversationBatch,
+	projectAgentConversationSnapshot,
+} from './conversation-public.ts';
+import { loadReducedConversationState } from './conversation-reader.ts';
+import type { ConversationRecord } from './conversation-records.ts';
+import {
+	REDUCED_STATE_FORMAT,
+	reduceConversationRecords,
+	toolResultEntryId,
+} from './conversation-reducer.ts';
+import { ConversationRecordWriter } from './conversation-writer.ts';
+import { sqlite } from './node/agent-execution-store.ts';
+import { processSubmission } from './runtime/agent-submissions.ts';
+import { defineConversationStreamStoreContractTests } from './test-utils/define-conversation-stream-store-contract-tests.ts';
+
+const path = 'agents/echo/case-a';
+const identity = { agentName: 'echo', instanceId: 'case-a' };
+const scope = { conversationId: 'conv_case_a', harness: 'default', session: 'default' };
+const timestamp = '2026-09-11T00:00:00.000Z';
+const envelope = { v: 1 as const, ...scope, timestamp };
+const oldAttempt = { submissionId: 'old', attemptId: 'first-attempt' };
+const secondAttempt = { submissionId: 'old', attemptId: 'second-attempt' };
+const before = { submissionId: 'next', attemptId: 'next-attempt' };
+const usage = {
+	input: 0,
+	output: 0,
+	cacheRead: 0,
+	cacheWrite: 0,
+	totalTokens: 0,
+	cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+const adapters: ReturnType<typeof sqlite>[] = [];
+
+afterEach(async () => {
+	vi.restoreAllMocks();
+	for (const adapter of adapters.splice(0)) await adapter.close?.();
+});
+
+async function stores() {
+	const adapter = sqlite();
+	adapters.push(adapter);
+	await adapter.migrate?.();
+	const connected = await adapter.connect();
+	return { stream: connected.conversationStreamStore, submissions: connected.submissionStore };
+}
+
+async function claim(submissions: AgentSubmissionStore, attempt = before) {
+	await submissions.admitDirect({
+		kind: 'direct',
+		submissionId: attempt.submissionId,
+		agent: 'echo',
+		id: 'case-a',
+		message: { kind: 'user', body: 'next input' },
+		acceptedAt: timestamp,
+	});
+	await submissions.markSubmissionCanonicalReady(attempt.submissionId);
+	await submissions.claimSubmission({
+		...attempt,
+		ownerId: 'test',
+		leaseExpiresAt: Date.now() + 30_000,
+	});
+}
+
+async function fixture(settle = true) {
+	const { stream, submissions } = await stores();
+	const writer = await ConversationRecordWriter.create({
+		store: stream,
+		path,
+		identity,
+		producerId: 'first',
+	});
+	await writer.ensureConversation({
+		...scope,
+		kind: 'root',
+		affinityKey: 'case-a',
+		createdAt: timestamp,
+	});
+	await writer.append([
+		{
+			...envelope,
+			id: 'history-open',
+			type: 'assistant_message_started',
+			messageId: 'entry_history',
+			parentId: null,
+			modelInfo: { api: 'openai-responses', provider: 'test', model: 'test' },
+		},
+		{
+			...envelope,
+			id: 'history-call',
+			type: 'assistant_tool_call',
+			messageId: 'entry_history',
+			blockId: 'history-block',
+			blockIndex: 0,
+			toolCallId: 'history-call',
+			name: 'saved-tool',
+			arguments: {},
+		},
+		{
+			...envelope,
+			id: 'history-complete',
+			type: 'assistant_message_completed',
+			messageId: 'entry_history',
+			stopReason: 'toolUse',
+			usage,
+		},
+		{
+			...envelope,
+			id: 'history-outcome',
+			type: 'tool_outcome',
+			assistantMessageId: 'entry_history',
+			toolCallId: 'history-call',
+			toolName: 'saved-tool',
+			isError: false,
+			content: [{ type: 'text', text: 'saved result' }],
+		},
+		{
+			...envelope,
+			id: 'history-commit',
+			type: 'tool_results_committed',
+			assistantMessageId: 'entry_history',
+			parentId: 'entry_history',
+			outcomeIds: ['history-outcome'],
+		},
+	]);
+	await submissions.admitDispatch({
+		submissionId: 'old',
+		agent: 'echo',
+		id: 'case-a',
+		message: { kind: 'user', body: 'old input' },
+		acceptedAt: timestamp,
+	});
+	await submissions.markSubmissionCanonicalReady('old');
+	await submissions.claimSubmission({
+		...oldAttempt,
+		ownerId: 'test',
+		leaseExpiresAt: Date.now() + 30_000,
+	});
+	await writer.append(
+		[
+			{
+				...envelope,
+				...oldAttempt,
+				id: 'input-old',
+				type: 'user_message',
+				messageId: 'entry_user_old',
+				parentId: toolResultEntryId('entry_history', 'history-call'),
+				content: [{ type: 'text', text: 'old input' }],
+			},
+			{
+				...envelope,
+				...oldAttempt,
+				id: 'open-old',
+				type: 'assistant_message_started',
+				messageId: 'entry_abandoned',
+				parentId: 'entry_user_old',
+				modelInfo: { api: 'openai-responses', provider: 'test', model: 'test' },
+			},
+			{
+				...envelope,
+				...oldAttempt,
+				id: 'old-tool',
+				type: 'assistant_tool_call',
+				messageId: 'entry_abandoned',
+				blockId: 'tool-block',
+				blockIndex: 0,
+				toolCallId: 'old-call',
+				name: 'old-tool',
+				arguments: {},
+			},
+		],
+		{ submission: oldAttempt },
+	);
+	await submissions.replaceSubmissionAttempt(oldAttempt, secondAttempt.attemptId);
+	await writer.append(
+		[
+			{
+				...envelope,
+				...secondAttempt,
+				id: 'open-sibling',
+				type: 'assistant_message_started',
+				messageId: 'entry_sibling',
+				parentId: 'entry_user_old',
+				modelInfo: { api: 'openai-responses', provider: 'test', model: 'test' },
+			},
+			{
+				...envelope,
+				...secondAttempt,
+				id: 'complete-sibling',
+				type: 'assistant_message_completed',
+				messageId: 'entry_sibling',
+				stopReason: 'stop',
+				usage,
+			},
+		],
+		{ submission: secondAttempt },
+	);
+	if (settle) await submissions.completeSubmission(secondAttempt);
+	await claim(submissions);
+	return { stream, submissions, writer };
+}
+
+function nextInput(): ConversationRecord {
+	return {
+		...envelope,
+		...before,
+		id: 'next-input',
+		type: 'user_message',
+		messageId: 'entry_next_user',
+		parentId: 'entry_sibling',
+		content: [{ type: 'text', text: 'next input' }],
+	};
+}
+
+describe('abandoned message cleanup', () => {
+	it.each([false, true])('awaits cleanup before input; append failure = %s', async (failAppend) => {
+		const { stream, submissions, writer } = await fixture();
+		const submission = await submissions.getSubmission(before.submissionId);
+		if (!submission) throw new Error('Missing next submission');
+		const ctx = createFlueContext({
+			id: identity.instanceId,
+			agentName: identity.agentName,
+			submissionId: before.submissionId,
+			env: {},
+			agentConfig: { resolveModel: () => undefined },
+			conversationWriter: writer,
+		});
+		const processInput = vi.fn(() =>
+			writer.append([nextInput()], { submission: before }).then(() => undefined),
+		);
+		vi.spyOn(ctx, 'initializeRootHarness').mockResolvedValue({
+			session: async () => ({ processSubmissionInput: processInput }),
+		} as unknown as Awaited<ReturnType<typeof ctx.initializeRootHarness>>);
+		const entered = Promise.withResolvers<void>();
+		const release = Promise.withResolvers<void>();
+		const append = stream.append.bind(stream);
+		vi.spyOn(stream, 'append').mockImplementation(async (input) => {
+			if (input.abandonedMessage) {
+				entered.resolve();
+				await release.promise;
+				if (failAppend) throw new Error('cleanup append failed');
+			}
+			return append(input);
+		});
+		const execution = processSubmission({
+			submissions,
+			submission,
+			conversationWriter: writer,
+			resolveAgent: () => () => '',
+			createContext: () => ctx,
+		});
+		await entered.promise;
+		expect(processInput).not.toHaveBeenCalled();
+		release.resolve();
+		if (failAppend) {
+			await expect(execution).rejects.toThrow('cleanup append failed');
+			expect(processInput).not.toHaveBeenCalled();
+		} else {
+			await execution;
+			expect(processInput).toHaveBeenCalledOnce();
+			expect(
+				(await loadReducedConversationState({ store: stream, path })).conversations.get(
+					scope.conversationId,
+				)?.activeLeafId,
+			).toBe('entry_next_user');
+		}
+	});
+
+	it('clears the earlier attempt, preserves history, and permits later input after a fresh read', async () => {
+		const { stream, submissions, writer } = await fixture();
+		const oldRow = await submissions.getSubmission('old');
+		const rawBefore = (await stream.read(path)).batches;
+		const previous = await writer.loadReducedState();
+		await expect(writer.append([nextInput()], { submission: before })).rejects.toThrow(/stream/i);
+		await writer.clearAbandonedMessages(submissions, before);
+		const state = await loadReducedConversationState({ store: stream, path });
+		const conversation = state.conversations.get(scope.conversationId);
+		expect(conversation?.inProgressMessages.size).toBe(0);
+		expect(conversation?.activeLeafId).toBe('entry_sibling');
+		expect(conversation?.entries).toEqual(
+			previous.conversations.get(scope.conversationId)?.entries,
+		);
+		expect(conversation?.toolOutcomes).toEqual(
+			previous.conversations.get(scope.conversationId)?.toolOutcomes,
+		);
+		expect(
+			conversation?.entries.get(toolResultEntryId('entry_history', 'history-call')),
+		).toMatchObject({
+			message: { role: 'toolResult', content: [{ type: 'text', text: 'saved result' }] },
+		});
+		expect(await submissions.getSubmission('old')).toEqual(oldRow);
+		const batches = (await stream.read(path)).batches;
+		expect(batches.slice(0, -1)).toEqual(rawBefore);
+		const record = batches.at(-1)?.records[0];
+		expect(record).toMatchObject({
+			v: 2,
+			type: 'assistant_message_abandoned',
+			submissionId: 'old',
+			messageId: 'entry_abandoned',
+		});
+		expect(record).not.toHaveProperty('attemptId');
+		expect(record).not.toHaveProperty('outcome');
+		expect(record?.id).toBe(
+			abandonedMessageRecordId(scope.conversationId, 'old', 'entry_abandoned'),
+		);
+		expect(
+			projectAgentConversationBatch({
+				state,
+				previousState: previous,
+				records: [record as ConversationRecord],
+				batchOrdinal: batches.length - 1,
+			}),
+		).toEqual([
+			{
+				type: 'conversation-reset',
+				conversationId: scope.conversationId,
+				snapshot: projectAgentConversationSnapshot(state),
+				position: { batch: batches.length - 1, index: 0 },
+			},
+		]);
+		await writer.clearAbandonedMessages(submissions, before);
+		expect((await stream.read(path)).batches).toEqual(batches);
+		const freshWriter = await ConversationRecordWriter.create({
+			store: stream,
+			path,
+			identity,
+			producerId: 'fresh',
+		});
+		await freshWriter.clearAbandonedMessages(submissions, before);
+		await freshWriter.append([nextInput()], { submission: before });
+		const fresh = await loadReducedConversationState({ store: stream, path });
+		expect(fresh.conversations.get(scope.conversationId)?.activeLeafId).toBe('entry_next_user');
+	});
+
+	it('drains pending completion before selecting the old message', async () => {
+		const { stream, submissions, writer } = await fixture();
+		await writer.clearAbandonedMessages(submissions, before);
+		const pending = writer.enqueue(
+			[
+				{
+					...envelope,
+					...before,
+					id: 'next-open',
+					type: 'assistant_message_started',
+					messageId: 'entry_next_answer',
+					parentId: 'entry_sibling',
+					modelInfo: { api: 'openai-responses', provider: 'test', model: 'test' },
+				},
+				{
+					...envelope,
+					...before,
+					id: 'next-complete',
+					type: 'assistant_message_completed',
+					messageId: 'entry_next_answer',
+					stopReason: 'stop',
+					usage,
+				},
+			],
+			{ submission: before },
+		);
+		await writer.clearAbandonedMessages(submissions, before);
+		await pending;
+		expect(
+			(await loadReducedConversationState({ store: stream, path })).conversations.get(
+				scope.conversationId,
+			)?.activeLeafId,
+		).toBe('entry_next_answer');
+	});
+
+	it('keeps refusal when the target is still running', async () => {
+		const { stream, submissions, writer } = await fixture(false);
+		const initial = (await stream.read(path)).batches;
+		await expect(writer.clearAbandonedMessages(submissions, before)).rejects.toThrow();
+		expect((await stream.read(path)).batches).toEqual(initial);
+		await expect(writer.append([nextInput()], { submission: before })).rejects.toThrow(/stream/i);
+	});
+
+	it('keeps an open message at the active tail', async () => {
+		const { stream, submissions, writer } = await fixture();
+		await writer.append(
+			[
+				{
+					...envelope,
+					...before,
+					id: 'tail-open',
+					type: 'assistant_message_started',
+					messageId: 'entry_tail',
+					parentId: 'entry_sibling',
+					modelInfo: { api: 'openai-responses', provider: 'test', model: 'test' },
+				},
+			],
+			{ submission: before },
+		);
+		await writer.clearAbandonedMessages(submissions, before);
+		const conversation = (
+			await loadReducedConversationState({ store: stream, path })
+		).conversations.get(scope.conversationId);
+		expect([...(conversation?.inProgressMessages.keys() ?? [])]).toEqual(['entry_tail']);
+		expect(conversation?.activeLeafId).toBe('entry_sibling');
+		await expect(writer.append([nextInput()], { submission: before })).rejects.toThrow();
+	});
+
+	it('propagates row-read and append failures without clearing the message', async () => {
+		const { stream, submissions, writer } = await fixture();
+		const read = vi
+			.spyOn(submissions, 'getSubmission')
+			.mockRejectedValueOnce(new Error('row read failed'));
+		await expect(writer.clearAbandonedMessages(submissions, before)).rejects.toThrow(
+			'row read failed',
+		);
+		read.mockRestore();
+		vi.spyOn(stream, 'append').mockRejectedValue(new Error('append failed'));
+		await expect(writer.clearAbandonedMessages(submissions, before)).rejects.toThrow(
+			'append failed',
+		);
+		const state = await loadReducedConversationState({ store: stream, path });
+		expect(
+			state.conversations.get(scope.conversationId)?.inProgressMessages.has('entry_abandoned'),
+		).toBe(true);
+		expect(state.conversations.get(scope.conversationId)?.activeLeafId).toBe('entry_sibling');
+	});
+
+	it('rejects a successor replaced between the writer read and the storage transaction', async () => {
+		const { stream, submissions, writer } = await fixture();
+		const original = submissions.getSubmission.bind(submissions);
+		vi.spyOn(submissions, 'getSubmission').mockImplementation(async (id) => {
+			const row = await original(id);
+			if (id === 'old') await submissions.replaceSubmissionAttempt(before, 'replacement');
+			return row;
+		});
+		await expect(writer.clearAbandonedMessages(submissions, before)).rejects.toMatchObject({
+			meta: { reason: 'Abandoned message successor attempt is no longer running.' },
+		});
+		expect(
+			(await loadReducedConversationState({ store: stream, path })).conversations
+				.get(scope.conversationId)
+				?.inProgressMessages.has('entry_abandoned'),
+		).toBe(true);
+	});
+
+	it('rebuilds an old checkpoint and restores a new checkpoint with cleanup applied', async () => {
+		const { stream, submissions, writer } = await fixture();
+		const oldState = await writer.loadReducedState();
+		const meta = await stream.getMeta(path);
+		if (!meta) throw new Error('Missing test stream');
+		await stream.putFoldCheckpoint?.(path, {
+			offset: oldState.recordsThroughOffset,
+			incarnation: meta.incarnation,
+			formatVersion: REDUCED_STATE_FORMAT - 1,
+			data: encodeReducedInstanceState(oldState),
+		});
+		await writer.clearAbandonedMessages(submissions, before);
+		const fresh = await loadReducedConversationState({ store: stream, path });
+		expect(fresh.conversations.get(scope.conversationId)?.inProgressMessages.size).toBe(0);
+		await stream.putFoldCheckpoint?.(path, {
+			offset: fresh.recordsThroughOffset,
+			incarnation: meta.incarnation,
+			formatVersion: REDUCED_STATE_FORMAT,
+			data: encodeReducedInstanceState(fresh),
+		});
+		expect(await loadReducedConversationState({ store: stream, path })).toEqual(fresh);
+		const record = (await stream.read(path)).batches.at(-1)?.records[0];
+		if (!record) throw new Error('Missing cleanup record');
+		expect(reduceConversationRecords(fresh, [record], fresh.recordsThroughOffset)).toEqual(fresh);
+	});
+});
+
+defineConversationStreamStoreContractTests('SQLite conversation store', {
+	async create() {
+		const { stream, submissions } = await stores();
+		return { stream, submissionStore: submissions };
+	},
+});

--- a/packages/runtime/src/abandoned-message.ts
+++ b/packages/runtime/src/abandoned-message.ts
@@ -1,0 +1,194 @@
+import * as v from 'valibot';
+import type { SubmissionAttemptRef } from './agent-execution-store.ts';
+import {
+	type AssistantMessageAbandonedRecord,
+	type ConversationRecord,
+	encodeCanonicalId,
+} from './conversation-records.ts';
+import { parseSessionStorageKey } from './session-identity.ts';
+
+/** Stored evidence for one old dispatch. No old attempt or outcome is inferred. */
+export interface AbandonedMessageAuthorization {
+	before: SubmissionAttemptRef;
+	target: {
+		submissionId: string;
+		sessionKey: string;
+		sequence: number;
+		settledAt: number;
+	};
+}
+
+type Check<T> = { ok: true; value: T } | { ok: false; reason: string };
+
+const Id = v.pipe(v.string(), v.minLength(1));
+const Sequence = v.pipe(v.number(), v.safeInteger(), v.minValue(1));
+const Timestamp = v.pipe(
+	v.number(),
+	v.safeInteger(),
+	v.minValue(0),
+	v.maxValue(8_640_000_000_000_000),
+);
+const RecordSchema = v.strictObject({
+	v: v.literal(2),
+	id: Id,
+	type: v.literal('assistant_message_abandoned'),
+	conversationId: Id,
+	harness: v.literal('default'),
+	session: v.literal('default'),
+	timestamp: v.pipe(
+		v.string(),
+		v.check((value) => {
+			const at = Date.parse(value);
+			return Number.isFinite(at) && new Date(at).toISOString() === value;
+		}),
+	),
+	submissionId: Id,
+	messageId: Id,
+});
+const AuthorizationSchema = v.strictObject({
+	before: v.strictObject({ submissionId: Id, attemptId: Id }),
+	target: v.strictObject({
+		submissionId: Id,
+		sessionKey: Id,
+		sequence: Sequence,
+		settledAt: Timestamp,
+	}),
+});
+const RowSchema = v.object({
+	submissionId: Id,
+	sessionKey: Id,
+	sequence: Sequence,
+	kind: v.picklist(['direct', 'dispatch']),
+	status: v.picklist(['queued', 'running', 'terminalizing', 'settled', 'joining', 'joined']),
+	attemptId: v.nullish(Id),
+	joinedInto: v.nullish(Id),
+	settledAt: v.nullish(Timestamp),
+});
+const StreamSchema = v.object({ agentName: Id, instanceId: Id });
+
+/** Each message has one cleanup ID, across successors and retries. */
+export function abandonedMessageRecordId(
+	conversationId: string,
+	submissionId: string,
+	messageId: string,
+): string {
+	return `record_abandoned_${encodeCanonicalId(JSON.stringify([conversationId, submissionId, messageId]))}`;
+}
+
+/** Parse the new record before it enters the reducer or a storage adapter. */
+export function parseAbandonedMessageRecord(
+	value: unknown,
+): Check<AssistantMessageAbandonedRecord> {
+	const parsed = v.safeParse(RecordSchema, value);
+	if (!parsed.success) return { ok: false, reason: 'Abandoned message record is malformed.' };
+	const record = parsed.output;
+	if (
+		record.id !==
+		abandonedMessageRecordId(record.conversationId, record.submissionId, record.messageId)
+	) {
+		return { ok: false, reason: 'Abandoned message record ID does not match its target.' };
+	}
+	return { ok: true, value: record };
+}
+
+/** Only a single cleanup record can use terminal-row evidence instead of an old attempt. */
+export function parseAbandonedMessageBatch(
+	records: readonly ConversationRecord[],
+	authorization: unknown,
+	submission: unknown,
+): Check<
+	| { record: AssistantMessageAbandonedRecord; authorization: AbandonedMessageAuthorization }
+	| undefined
+> {
+	const hasCleanup = records.some((record) => record.type === 'assistant_message_abandoned');
+	if (authorization === undefined && !hasCleanup) return { ok: true, value: undefined };
+	if (submission !== undefined || records.length !== 1 || !hasCleanup) {
+		return {
+			ok: false,
+			reason: 'Abandoned message cleanup requires one dedicated record and no ordinary attempt.',
+		};
+	}
+	const parsedRecord = parseAbandonedMessageRecord(records[0]);
+	if (!parsedRecord.ok) return parsedRecord;
+	const parsed = v.safeParse(AuthorizationSchema, authorization);
+	if (!parsed.success)
+		return { ok: false, reason: 'Abandoned message authorization is malformed.' };
+	if (parsed.output.target.submissionId !== parsedRecord.value.submissionId) {
+		return { ok: false, reason: 'Abandoned message authorization names another target.' };
+	}
+	return { ok: true, value: { record: parsedRecord.value, authorization: parsed.output } };
+}
+
+/** Check current stored rows inside the append transaction, without changing the old row. */
+export function checkAbandonedMessageRows(
+	authorization: AbandonedMessageAuthorization,
+	targetValue: unknown,
+	beforeValue: unknown,
+	streamValue: unknown,
+): Check<void> {
+	const target = v.safeParse(RowSchema, targetValue);
+	const before = v.safeParse(RowSchema, beforeValue);
+	const stream = v.safeParse(StreamSchema, streamValue);
+	if (!target.success || !before.success || !stream.success) {
+		return { ok: false, reason: 'Abandoned message stored evidence is missing or malformed.' };
+	}
+	const old = target.output;
+	const next = before.output;
+	const selected = authorization.target;
+	if (
+		old.kind !== 'dispatch' ||
+		old.status !== 'settled' ||
+		old.joinedInto != null ||
+		old.settledAt == null
+	) {
+		return { ok: false, reason: 'Abandoned message target is not a settled unjoined dispatch.' };
+	}
+	if (
+		old.submissionId !== selected.submissionId ||
+		old.sessionKey !== selected.sessionKey ||
+		old.sequence !== selected.sequence ||
+		old.settledAt !== selected.settledAt
+	) {
+		return { ok: false, reason: 'Abandoned message terminal evidence changed.' };
+	}
+	if (
+		next.submissionId !== authorization.before.submissionId ||
+		next.attemptId !== authorization.before.attemptId ||
+		next.status !== 'running'
+	) {
+		return { ok: false, reason: 'Abandoned message successor attempt is no longer running.' };
+	}
+	const session = parseSessionStorageKey(old.sessionKey);
+	if (
+		old.sessionKey !== next.sessionKey ||
+		old.sequence >= next.sequence ||
+		!session ||
+		session.harness !== 'default' ||
+		session.session !== 'default' ||
+		session.agentName !== stream.output.agentName ||
+		session.instanceId !== stream.output.instanceId
+	) {
+		return {
+			ok: false,
+			reason: 'Abandoned message target is outside the earlier submission scope.',
+		};
+	}
+	return { ok: true, value: undefined };
+}
+
+/** SQL drivers can return integer columns as decimal strings. Other values remain invalid. */
+export function abandonedMessageSqlRow(row: Record<string, unknown> | undefined): unknown {
+	if (!row) return undefined;
+	const integer = (value: unknown): unknown =>
+		typeof value === 'string' && /^\d+$/.test(value) ? Number(value) : value;
+	return {
+		submissionId: row.submission_id,
+		sessionKey: row.session_key,
+		sequence: integer(row.sequence),
+		kind: row.kind,
+		status: row.status,
+		attemptId: row.attempt_id,
+		joinedInto: row.joined_into,
+		settledAt: integer(row.settled_at),
+	};
+}

--- a/packages/runtime/src/adapter.ts
+++ b/packages/runtime/src/adapter.ts
@@ -96,7 +96,14 @@ export {
 
 // ─── Canonical conversation stream store ────────────────────────────────────
 
+export type { AbandonedMessageAuthorization } from './abandoned-message.ts';
+export {
+	abandonedMessageSqlRow,
+	checkAbandonedMessageRows,
+	parseAbandonedMessageBatch,
+} from './abandoned-message.ts';
 export type {
+	AssistantMessageAbandonedRecord,
 	AttachmentRef,
 	ConversationRecord,
 	SubmissionSettledRecord,

--- a/packages/runtime/src/conversation-public.ts
+++ b/packages/runtime/src/conversation-public.ts
@@ -276,7 +276,11 @@ function withPositions(
 }
 
 function requiresSnapshotReset(record: ConversationRecord): boolean {
-	return record.type === 'conversation_created' || record.type === 'compaction';
+	return (
+		record.type === 'conversation_created' ||
+		record.type === 'compaction' ||
+		record.type === 'assistant_message_abandoned'
+	);
 }
 
 function encodeRecord(

--- a/packages/runtime/src/conversation-records.ts
+++ b/packages/runtime/src/conversation-records.ts
@@ -328,6 +328,22 @@ export interface SubmissionSettledRecord extends ConversationRecordEnvelope {
 	error?: unknown;
 }
 
+/** Version 2 makes older readers refuse cleanup instead of keeping stale open state. */
+export interface AssistantMessageAbandonedRecord extends Omit<
+	ConversationRecordEnvelope,
+	'v' | 'attemptId'
+> {
+	v: 2;
+	type: 'assistant_message_abandoned';
+	harness: 'default';
+	session: 'default';
+	submissionId: string;
+	messageId: string;
+	attemptId?: never;
+	operationId?: never;
+	turnId?: never;
+}
+
 /**
  * One durable write to the agent instance's hook state (`usePersistentState`). The
  * record log is the source of truth: the current value of a state name is the
@@ -457,6 +473,7 @@ export type ConversationRecord =
 	| CompactionRecord
 	| ChildSessionRetainedRecord
 	| SubmissionSettledRecord
+	| AssistantMessageAbandonedRecord
 	| StateWriteRecord
 	| AgentStartRunRecord
 	| AgentFinishCycleRecord

--- a/packages/runtime/src/conversation-reducer.ts
+++ b/packages/runtime/src/conversation-reducer.ts
@@ -1,5 +1,6 @@
 import type { AgentMessage } from '@earendil-works/pi-agent-core';
 import type { AssistantMessage, ToolResultMessage, UserMessage } from '@earendil-works/pi-ai';
+import { parseAbandonedMessageRecord } from './abandoned-message.ts';
 import {
 	type AssistantMessageStartedRecord,
 	type AttachmentRef,
@@ -331,7 +332,7 @@ export interface ReducedContextEntry {
  * against from-scratch folds at every batch boundary, so shape drift without
  * a matching codec change fails CI.
  */
-export const REDUCED_STATE_FORMAT = 2;
+export const REDUCED_STATE_FORMAT = 3;
 
 export function createReducedInstanceState(): ReducedInstanceState {
 	return {
@@ -453,7 +454,10 @@ export function applyConversationRecord(
 		if (identical) return;
 		fail(record, `Record id "${record.id}" was reused with different content.`);
 	}
-	if (record.v !== 1) fail(record, `Record version "${String(record.v)}" is unsupported.`);
+	const version: number = record.v;
+	if (version !== 1 && !(version === 2 && record.type === 'assistant_message_abandoned')) {
+		fail(record, `Record version "${String(version)}" is unsupported.`);
+	}
 
 	if (record.type === 'conversation_created') {
 		validateConversationCreation(state, record);
@@ -824,6 +828,24 @@ export function applyConversationRecord(
 				fail(record, `Child conversation topology conflicts with an existing retained child.`);
 			}
 			conversation.childConversations.set(record.child.conversationId, record.child);
+			break;
+		}
+		case 'assistant_message_abandoned': {
+			const parsed = parseAbandonedMessageRecord(record);
+			if (!parsed.ok) fail(record, parsed.reason);
+			const message = conversation.inProgressMessages.get(parsed.value.messageId);
+			if (
+				!message ||
+				message.submissionId !== parsed.value.submissionId ||
+				message.parentId === conversation.activeLeafId
+			) {
+				fail(
+					record,
+					'Abandoned message must name an open message behind the tail for the same submission.',
+				);
+			}
+			// Keep raw records and completed entries. Only the selected stream stops being open.
+			conversation.inProgressMessages.delete(parsed.value.messageId);
 			break;
 		}
 		case 'submission_settled':

--- a/packages/runtime/src/conversation-writer.ts
+++ b/packages/runtime/src/conversation-writer.ts
@@ -1,3 +1,10 @@
+import {
+	type AbandonedMessageAuthorization,
+	abandonedMessageRecordId,
+	checkAbandonedMessageRows,
+	parseAbandonedMessageBatch,
+} from './abandoned-message.ts';
+import type { AgentSubmissionStore, SubmissionAttemptRef } from './agent-execution-store.ts';
 import { FOLD_CHECKPOINT_INTERVAL, writeFoldCheckpoint } from './conversation-fold-checkpoint.ts';
 import { type ConversationFoldHost, getConversationFoldHost } from './conversation-fold-host.ts';
 import type {
@@ -21,6 +28,7 @@ export interface ConversationRecordScope {
 
 export interface ConversationAppendOptions {
 	submission?: { submissionId: string; attemptId: string };
+	abandonedMessage?: AbandonedMessageAuthorization;
 }
 
 type ConversationCreationInput = ConversationCreatedRecord extends infer Record
@@ -60,6 +68,7 @@ export class ConversationRecordWriter {
 		private readonly store: ConversationStreamStore,
 		readonly path: string,
 		private claim: ConversationProducerClaim,
+		private readonly streamIdentity: ConversationStreamIdentity,
 		private readonly onFailed?: (writer: ConversationRecordWriter) => void,
 	) {
 		this.nextProducerSequence = claim.nextProducerSequence;
@@ -76,7 +85,13 @@ export class ConversationRecordWriter {
 	}): Promise<ConversationRecordWriter> {
 		await options.store.createStream(options.path, options.identity);
 		const claim = await options.store.acquireProducer(options.path, options.producerId);
-		return new ConversationRecordWriter(options.store, options.path, claim, options.onFailed);
+		return new ConversationRecordWriter(
+			options.store,
+			options.path,
+			claim,
+			options.identity,
+			options.onFailed,
+		);
 	}
 
 	async loadReducedState(): Promise<ReducedInstanceState> {
@@ -222,67 +237,153 @@ export class ConversationRecordWriter {
 		}
 	}
 
-	private appendBatch(
-		records: readonly ConversationRecord[],
-		options: ConversationAppendOptions,
-	): Promise<{ offset: string }> {
-		const operation = this.tail.then(async () => {
-			this.assertActive();
-			const reduced = this.reducedState
-				? reduceConversationRecords(
-						this.reducedState,
-						records,
-						this.reducedState.recordsThroughOffset,
-					)
-				: undefined;
-			const producerSequence = this.nextProducerSequence;
-			const input = {
-				path: this.path,
-				producerId: this.claim.producerId,
-				producerEpoch: this.claim.producerEpoch,
-				incarnation: this.claim.incarnation,
-				producerSequence,
-				...(options.submission ? { submission: options.submission } : {}),
-				records,
-			};
-			try {
-				let result: { offset: string };
-				try {
-					result = await this.store.append(input);
-				} catch (firstError) {
-					try {
-						result = await this.store.append(input);
-					} catch {
-						throw firstError;
-					}
+	/** Clear only old terminal dispatch messages before this attempt appends its input. */
+	async clearAbandonedMessages(
+		submissions: Pick<AgentSubmissionStore, 'getSubmission'>,
+		before: SubmissionAttemptRef,
+	): Promise<void> {
+		await this.flush();
+		return this.serialize(async () => {
+			const state = await this.loadReducedState();
+			const conversation = [...state.conversations.values()].find(
+				(value) => value.harness === 'default' && value.session === 'default',
+			);
+			if (!conversation) return;
+			const candidates = [...conversation.inProgressMessages.values()].filter(
+				(message) => message.parentId !== conversation.activeLeafId,
+			);
+			if (candidates.length === 0) return;
+			if (!this.store.supportsAbandonedMessageCleanup) {
+				throw new Error(
+					'[flue] Abandoned message cleanup requires transactional submission storage.',
+				);
+			}
+			const next = await submissions.getSubmission(before.submissionId);
+			for (const message of candidates) {
+				if (!message.submissionId)
+					throw new Error('[flue] Abandoned message has no stored submission.');
+				const old = await submissions.getSubmission(message.submissionId);
+				const record: ConversationRecord = {
+					v: 2,
+					id: abandonedMessageRecordId(
+						conversation.conversationId,
+						message.submissionId,
+						message.messageId,
+					),
+					type: 'assistant_message_abandoned',
+					conversationId: conversation.conversationId,
+					harness: 'default',
+					session: 'default',
+					timestamp: new Date().toISOString(),
+					submissionId: message.submissionId,
+					messageId: message.messageId,
+				};
+				const parsed = parseAbandonedMessageBatch(
+					[record],
+					{
+						before,
+						target: {
+							submissionId: old?.submissionId,
+							sessionKey: old?.sessionKey,
+							sequence: old?.sequence,
+							settledAt: old?.settledAt,
+						},
+					},
+					undefined,
+				);
+				if (!parsed.ok) throw new Error(`[flue] ${parsed.reason}`);
+				if (!parsed.value) throw new Error('[flue] Cleanup record is missing.');
+				const checked = checkAbandonedMessageRows(
+					parsed.value.authorization,
+					old,
+					next,
+					this.streamIdentity,
+				);
+				if (!checked.ok) throw new Error(`[flue] ${checked.reason}`);
+				// Enqueues do not take the writer queue. Refuse if a producer buffers more work during the read.
+				if (this.pendingRecords.length > 0) {
+					throw new Error(
+						'[flue] Pending conversation writes must finish before abandoned message cleanup.',
+					);
 				}
-				this.nextProducerSequence = producerSequence + 1;
-				if (reduced) {
-					reduced.recordsThroughOffset = result.offset;
-					this.reducedState = reduced;
-					this.foldHost.adoptState(reduced, this.claim.incarnation);
-					// Durable fold checkpoint. The encode is synchronous (states
-					// are never mutated after publication, so it reads a stable
-					// snapshot); the store write floats off the append's critical
-					// path — the batch is durable either way, and a lost
-					// checkpoint just means the next cold load folds a longer
-					// suffix.
-					this.batchesSinceFoldCheckpoint += 1;
-					if (this.batchesSinceFoldCheckpoint >= FOLD_CHECKPOINT_INTERVAL) {
-						this.batchesSinceFoldCheckpoint = 0;
-						writeFoldCheckpoint(this.store, this.path, reduced, this.claim.incarnation);
-					}
-				}
-				return result;
-			} catch (error) {
-				throw this.fail(error);
+				await this.appendNow([parsed.value.record], {
+					abandonedMessage: parsed.value.authorization,
+				});
 			}
 		});
+	}
+
+	private serialize<T>(work: () => Promise<T>): Promise<T> {
+		const operation = this.tail.then(work);
 		this.tail = operation.then(
 			() => {},
 			() => {},
 		);
 		return operation;
+	}
+
+	private appendBatch(
+		records: readonly ConversationRecord[],
+		options: ConversationAppendOptions,
+	): Promise<{ offset: string }> {
+		return this.serialize(() => this.appendNow(records, options));
+	}
+
+	private async appendNow(
+		records: readonly ConversationRecord[],
+		options: ConversationAppendOptions,
+	): Promise<{ offset: string }> {
+		this.assertActive();
+		const reduced = this.reducedState
+			? reduceConversationRecords(
+					this.reducedState,
+					records,
+					this.reducedState.recordsThroughOffset,
+				)
+			: undefined;
+		const producerSequence = this.nextProducerSequence;
+		const input = {
+			path: this.path,
+			producerId: this.claim.producerId,
+			producerEpoch: this.claim.producerEpoch,
+			incarnation: this.claim.incarnation,
+			producerSequence,
+			...(options.submission ? { submission: options.submission } : {}),
+			...(options.abandonedMessage ? { abandonedMessage: options.abandonedMessage } : {}),
+			records,
+		};
+		try {
+			let result: { offset: string };
+			try {
+				result = await this.store.append(input);
+			} catch (firstError) {
+				try {
+					result = await this.store.append(input);
+				} catch {
+					throw firstError;
+				}
+			}
+			this.nextProducerSequence = producerSequence + 1;
+			if (reduced) {
+				reduced.recordsThroughOffset = result.offset;
+				this.reducedState = reduced;
+				this.foldHost.adoptState(reduced, this.claim.incarnation);
+				// Durable fold checkpoint. The encode is synchronous (states
+				// are never mutated after publication, so it reads a stable
+				// snapshot); the store write floats off the append's critical
+				// path — the batch is durable either way, and a lost
+				// checkpoint just means the next cold load folds a longer
+				// suffix.
+				this.batchesSinceFoldCheckpoint += 1;
+				if (this.batchesSinceFoldCheckpoint >= FOLD_CHECKPOINT_INTERVAL) {
+					this.batchesSinceFoldCheckpoint = 0;
+					writeFoldCheckpoint(this.store, this.path, reduced, this.claim.incarnation);
+				}
+			}
+			return result;
+		} catch (error) {
+			throw this.fail(error);
+		}
 	}
 
 	private assertActive(): void {
@@ -415,6 +516,7 @@ function sameAppendOptions(
 ): boolean {
 	return (
 		left.submission?.submissionId === right.submission?.submissionId &&
-		left.submission?.attemptId === right.submission?.attemptId
+		left.submission?.attemptId === right.submission?.attemptId &&
+		JSON.stringify(left.abandonedMessage) === JSON.stringify(right.abandonedMessage)
 	);
 }

--- a/packages/runtime/src/runtime/agent-submissions.ts
+++ b/packages/runtime/src/runtime/agent-submissions.ts
@@ -834,8 +834,9 @@ export async function processSubmission(opts: ProcessSubmissionOptions): Promise
 		listUnresolved: () => submissions.listJoinedSubmissions(attempt.submissionId),
 	};
 
-	const execute = () =>
-		createAgentSubmissionSessionHandler(agent, input, (session) => {
+	const execute = async () => {
+		await opts.conversationWriter?.clearAbandonedMessages(submissions, attempt);
+		return createAgentSubmissionSessionHandler(agent, input, (session) => {
 			const handle = session.processSubmissionInput(input, {
 				joinSource,
 				onInputApplied: async (durability: SubmissionDurability) => {
@@ -883,6 +884,7 @@ export async function processSubmission(opts: ProcessSubmissionOptions): Promise
 			}
 			return handle;
 		})(ctx);
+	};
 
 	// Pre-execution abort: a queued submission that was abort-flagged is still
 	// claimed (creating an attempt) so settlement is uniform and

--- a/packages/runtime/src/runtime/conversation-stream-store.ts
+++ b/packages/runtime/src/runtime/conversation-stream-store.ts
@@ -1,3 +1,9 @@
+import {
+	type AbandonedMessageAuthorization,
+	abandonedMessageSqlRow,
+	checkAbandonedMessageRows,
+	parseAbandonedMessageBatch,
+} from '../abandoned-message.ts';
 import { clampLimit } from '../adapter-helpers.ts';
 import type { AgentSubmissionStore } from '../agent-execution-store.ts';
 import type { ConversationRecord } from '../conversation-records.ts';
@@ -61,6 +67,8 @@ export interface ConversationFoldCheckpoint {
 }
 
 export interface ConversationStreamStore {
+	/** Enable cleanup only when append checks both stored rows in the same transaction as the record. */
+	readonly supportsAbandonedMessageCleanup?: true;
 	createStream(path: string, identity: ConversationStreamIdentity): Promise<void>;
 	acquireProducer(path: string, producerId: string): Promise<ConversationProducerClaim>;
 	/**
@@ -86,6 +94,7 @@ export interface ConversationStreamStore {
 		incarnation: string;
 		producerSequence: number;
 		submission?: { submissionId: string; attemptId: string };
+		abandonedMessage?: AbandonedMessageAuthorization;
 		records: readonly ConversationRecord[];
 	}): Promise<{ offset: string }>;
 	read(
@@ -341,6 +350,7 @@ export class InMemoryConversationStreamStore implements ConversationStreamStore 
 		incarnation: string;
 		producerSequence: number;
 		submission?: { submissionId: string; attemptId: string };
+		abandonedMessage?: AbandonedMessageAuthorization;
 		records: readonly ConversationRecord[];
 	}): Promise<{ offset: string }> {
 		// Whole appends are serialized: the submission fence awaits the
@@ -361,11 +371,18 @@ export class InMemoryConversationStreamStore implements ConversationStreamStore 
 		incarnation: string;
 		producerSequence: number;
 		submission?: { submissionId: string; attemptId: string };
+		abandonedMessage?: AbandonedMessageAuthorization;
 		records: readonly ConversationRecord[];
 	}): Promise<{ offset: string }> {
 		if (input.records.length === 0)
 			this.fail('append', input.path, 'A canonical batch cannot be empty.');
 		const data = JSON.stringify(input.records);
+		const cleanup = parseAbandonedMessageBatch(
+			input.records,
+			input.abandonedMessage,
+			input.submission,
+		);
+		if (!cleanup.ok) this.fail('append', input.path, cleanup.reason);
 		const stream = this.streams.get(input.path);
 		if (!stream) this.fail('append', input.path, 'Stream does not exist.');
 		if (
@@ -394,6 +411,13 @@ export class InMemoryConversationStreamStore implements ConversationStreamStore 
 		if (stream.nextProducerSequence !== input.producerSequence) {
 			this.fail('append', input.path, 'Producer sequence is not the next expected value.');
 		}
+		// This store cannot transact with an external submission store.
+		if (cleanup.value)
+			this.fail(
+				'append',
+				input.path,
+				'Abandoned message cleanup requires transactional submission storage.',
+			);
 		await this.assertSubmissionAuthorization(input.path, input.submission, input.records);
 		const offset = formatOffset(stream.batches.length);
 		stream.batches.push({
@@ -556,6 +580,7 @@ export class InMemoryConversationStreamStore implements ConversationStreamStore 
 // Object SQLite requires synchronous `transactionSync`, so this store cannot use
 // the async SQL builder and keeps its own synchronous fence implementation.
 export class SqliteConversationStreamStore implements ConversationStreamStore {
+	readonly supportsAbandonedMessageCleanup = true;
 	private listeners = new StreamListenerRegistry();
 
 	constructor(
@@ -615,11 +640,18 @@ export class SqliteConversationStreamStore implements ConversationStreamStore {
 		incarnation: string;
 		producerSequence: number;
 		submission?: { submissionId: string; attemptId: string };
+		abandonedMessage?: AbandonedMessageAuthorization;
 		records: readonly ConversationRecord[];
 	}): Promise<{ offset: string }> {
 		if (input.records.length === 0)
 			this.fail('append', input.path, 'A canonical batch cannot be empty.');
 		const data = JSON.stringify(input.records);
+		const cleanup = parseAbandonedMessageBatch(
+			input.records,
+			input.abandonedMessage,
+			input.submission,
+		);
+		if (!cleanup.ok) this.fail('append', input.path, cleanup.reason);
 		if (data.length > MAX_BATCH_DATA_LENGTH) {
 			this.fail('append', input.path, oversizedBatchReason(data.length, input.records));
 		}
@@ -638,6 +670,28 @@ export class SqliteConversationStreamStore implements ConversationStreamStore {
 				meta.incarnation !== input.incarnation
 			) {
 				this.fail('append', input.path, 'Producer ownership is stale.');
+			}
+			if (cleanup.value) {
+				const authorization = cleanup.value.authorization;
+				const read = (id: string) =>
+					abandonedMessageSqlRow(
+						this.sql
+							.exec(
+								'SELECT submission_id, session_key, sequence, kind, status, attempt_id, joined_into, settled_at FROM flue_agent_submissions WHERE submission_id = ?',
+								id,
+							)
+							.toArray()[0],
+					);
+				const streams = this.sql
+					.exec('SELECT identity_json FROM flue_conversation_streams WHERE path = ?', input.path)
+					.toArray();
+				const checked = checkAbandonedMessageRows(
+					authorization,
+					read(authorization.target.submissionId),
+					read(authorization.before.submissionId),
+					streams[0] ? JSON.parse(String(streams[0].identity_json)) : undefined,
+				);
+				if (!checked.ok) this.fail('append', input.path, checked.reason);
 			}
 			const retry = this.sql
 				.exec(
@@ -668,7 +722,9 @@ export class SqliteConversationStreamStore implements ConversationStreamStore {
 			if (meta.next_producer_sequence !== input.producerSequence) {
 				this.fail('append', input.path, 'Producer sequence is not the next expected value.');
 			}
-			this.assertSubmissionAuthorization(input.path, input.submission, input.records);
+			if (!cleanup.value) {
+				this.assertSubmissionAuthorization(input.path, input.submission, input.records);
+			}
 			const seq = meta.next_offset as number;
 			const stored =
 				data.length > CONVERSATION_BATCH_SPILL_THRESHOLD

--- a/packages/runtime/src/runtime/sql-conversation-stream-store.ts
+++ b/packages/runtime/src/runtime/sql-conversation-stream-store.ts
@@ -1,3 +1,9 @@
+import {
+	type AbandonedMessageAuthorization,
+	abandonedMessageSqlRow,
+	checkAbandonedMessageRows,
+	parseAbandonedMessageBatch,
+} from '../abandoned-message.ts';
 import { clampLimit } from '../adapter-helpers.ts';
 import type { ConversationRecord } from '../conversation-records.ts';
 import { ConversationStreamStoreError } from '../errors.ts';
@@ -63,6 +69,7 @@ export function defineSqlConversationStreamStore(
 }
 
 class SqlConversationStreamStore implements ConversationStreamStore {
+	readonly supportsAbandonedMessageCleanup = true;
 	private listeners = new StreamListenerRegistry();
 
 	constructor(private dialect: SqlConversationDialect) {}
@@ -141,6 +148,7 @@ class SqlConversationStreamStore implements ConversationStreamStore {
 		incarnation: string;
 		producerSequence: number;
 		submission?: { submissionId: string; attemptId: string };
+		abandonedMessage?: AbandonedMessageAuthorization;
 		records: readonly ConversationRecord[];
 	}): Promise<{ offset: string }> {
 		const dialect = this.dialect;
@@ -149,6 +157,12 @@ class SqlConversationStreamStore implements ConversationStreamStore {
 		if (input.records.length === 0)
 			throw failure(input.path, 'A canonical batch cannot be empty.', 'append');
 		const data = JSON.stringify(input.records);
+		const cleanup = parseAbandonedMessageBatch(
+			input.records,
+			input.abandonedMessage,
+			input.submission,
+		);
+		if (!cleanup.ok) throw failure(input.path, cleanup.reason);
 		if (data.length > MAX_BATCH_DATA_LENGTH) {
 			throw failure(input.path, oversizedBatchReason(data.length, input.records));
 		}
@@ -166,6 +180,29 @@ class SqlConversationStreamStore implements ConversationStreamStore {
 				meta.incarnation !== input.incarnation
 			) {
 				throw failure(input.path, 'Producer ownership is stale.');
+			}
+			if (cleanup.value) {
+				const authorization = cleanup.value.authorization;
+				const read = async (id: string) =>
+					abandonedMessageSqlRow(
+						(
+							await tx.query(
+								`SELECT submission_id, session_key, sequence, kind, status, attempt_id, joined_into, settled_at FROM flue_agent_submissions WHERE submission_id = ${p(1)} ${dialect.lockClause}`,
+								[id],
+							)
+						)[0],
+					);
+				const streams = await tx.query(
+					`SELECT identity_json FROM flue_conversation_streams WHERE path = ${p(1)}`,
+					[input.path],
+				);
+				const checked = checkAbandonedMessageRows(
+					authorization,
+					await read(authorization.target.submissionId),
+					await read(authorization.before.submissionId),
+					streams[0] ? JSON.parse(String(streams[0].identity_json)) : undefined,
+				);
+				if (!checked.ok) throw failure(input.path, checked.reason);
 			}
 			const retries = await tx.query(
 				`SELECT seq, data, submission_id, attempt_id FROM flue_conversation_stream_batches
@@ -186,7 +223,15 @@ class SqlConversationStreamStore implements ConversationStreamStore {
 			if (Number(meta.next_producer_sequence) !== input.producerSequence) {
 				throw failure(input.path, 'Producer sequence is not the next expected value.');
 			}
-			await assertSubmissionAuthorization(dialect, tx, input.path, input.submission, input.records);
+			if (!cleanup.value) {
+				await assertSubmissionAuthorization(
+					dialect,
+					tx,
+					input.path,
+					input.submission,
+					input.records,
+				);
+			}
 			const seq = Number(meta.next_offset);
 			await tx.query(
 				`INSERT INTO flue_conversation_stream_batches

--- a/packages/runtime/src/test-utils/define-conversation-stream-store-contract-tests.ts
+++ b/packages/runtime/src/test-utils/define-conversation-stream-store-contract-tests.ts
@@ -1,4 +1,8 @@
 import { afterEach, describe, expect, it } from 'vitest';
+import {
+	type AbandonedMessageAuthorization,
+	abandonedMessageRecordId,
+} from '../abandoned-message.ts';
 import type { AgentSubmissionStore } from '../agent-execution-store.ts';
 import type { ConversationRecord } from '../conversation-records.ts';
 import type { ConversationStreamStore } from '../runtime/conversation-stream-store.ts';
@@ -16,7 +20,11 @@ export interface ConversationStreamStoreContractBackend {
 	cleanup?(): void | Promise<void>;
 }
 
-function userRecord(id: string, messageId: string, text = messageId): ConversationRecord {
+function userRecord(
+	id: string,
+	messageId: string,
+	text = messageId,
+): Extract<ConversationRecord, { type: 'user_message' }> {
 	return {
 		v: 1,
 		id,
@@ -75,6 +83,142 @@ export function defineConversationStreamStoreContractTests(
 		afterEach(async () => {
 			await backend.cleanup?.();
 		});
+
+		async function cleanupInput() {
+			const { stream, submissionStore } = await create();
+			if (!submissionStore) {
+				if (stream.supportsAbandonedMessageCleanup)
+					throw new Error('Cleanup tests require submission storage.');
+				return undefined;
+			}
+			const path = 'agents/echo/contract';
+			await stream.createStream(path, { agentName: 'echo', instanceId: 'contract' });
+			const producer = await stream.acquireProducer(path, 'cleanup');
+			await submissionStore.admitDispatch({
+				submissionId: 'old',
+				agent: 'echo',
+				id: 'contract',
+				message: { kind: 'user', body: 'old' },
+				acceptedAt: '2026-09-11T00:00:00.000Z',
+			});
+			await submissionStore.markSubmissionCanonicalReady('old');
+			await submissionStore.claimSubmission({
+				submissionId: 'old',
+				attemptId: 'old-final',
+				ownerId: 'test',
+				leaseExpiresAt: Date.now() + 30_000,
+			});
+			await submissionStore.completeSubmission({ submissionId: 'old', attemptId: 'old-final' });
+			await claimContractSubmission(submissionStore, 'next', 'next-attempt');
+			const old = await submissionStore.getSubmission('old');
+			if (!old || old.settledAt === undefined) throw new Error('Missing settled test row.');
+			const abandonedMessage: AbandonedMessageAuthorization = {
+				before: { submissionId: 'next', attemptId: 'next-attempt' },
+				target: {
+					submissionId: 'old',
+					sessionKey: old.sessionKey,
+					sequence: old.sequence,
+					settledAt: old.settledAt,
+				},
+			};
+			const record: ConversationRecord = {
+				v: 2,
+				id: abandonedMessageRecordId('conv_contract', 'old', 'open'),
+				type: 'assistant_message_abandoned',
+				conversationId: 'conv_contract',
+				harness: 'default',
+				session: 'default',
+				timestamp: '2026-09-11T01:00:00.000Z',
+				submissionId: 'old',
+				messageId: 'open',
+			};
+			return {
+				stream,
+				submissionStore,
+				old,
+				input: { path, ...producer, producerSequence: 0, records: [record], abandonedMessage },
+			};
+		}
+
+		it('appends one cleanup record without changing the old row and keeps exact retry behavior', async ({
+			skip,
+		}) => {
+			const fixture = await cleanupInput();
+			if (!fixture) return skip();
+			const { stream, submissionStore, input, old } = fixture;
+			if (!stream.supportsAbandonedMessageCleanup) {
+				await expect(stream.append(input)).rejects.toThrow();
+				return;
+			}
+			const result = await stream.append(input);
+			expect(await stream.append(input)).toEqual(result);
+			expect(await submissionStore.getSubmission('old')).toEqual(old);
+			expect((await stream.read(input.path)).batches).toHaveLength(1);
+			await expect(
+				stream.append({
+					...input,
+					abandonedMessage: {
+						...input.abandonedMessage,
+						target: {
+							...input.abandonedMessage.target,
+							settledAt: input.abandonedMessage.target.settledAt + 1,
+						},
+					},
+				}),
+			).rejects.toThrow();
+			await expect(
+				stream.append({
+					...input,
+					records: [
+						{ ...input.records[0], timestamp: '2026-09-11T02:00:00.000Z' } as ConversationRecord,
+					],
+				}),
+			).rejects.toThrow();
+		});
+
+		for (const condition of [
+			'missing-mode',
+			'mixed-batch',
+			'ordinary-attempt',
+			'wrong-target',
+			'changed-time',
+			'changed-sequence',
+			'foreign-session',
+			'stale-attempt',
+			'stale-producer',
+			'sequence-gap',
+		] as const) {
+			it(`refuses cleanup with ${condition} and writes no record`, async ({ skip }) => {
+				const fixture = await cleanupInput();
+				if (!fixture) return skip();
+				const { stream, input } = fixture;
+				if (condition === 'missing-mode') {
+					await expect(stream.append({ ...input, abandonedMessage: undefined })).rejects.toThrow();
+				} else if (condition === 'mixed-batch') {
+					await expect(
+						stream.append({ ...input, records: [...input.records, userRecord('extra', 'extra')] }),
+					).rejects.toThrow();
+				} else if (condition === 'ordinary-attempt') {
+					await expect(
+						stream.append({ ...input, submission: input.abandonedMessage.before }),
+					).rejects.toThrow();
+				} else {
+					if (condition === 'wrong-target') input.abandonedMessage.target.submissionId = 'missing';
+					if (condition === 'changed-time') input.abandonedMessage.target.settledAt += 1;
+					if (condition === 'changed-sequence') input.abandonedMessage.target.sequence += 1;
+					if (condition === 'foreign-session')
+						input.abandonedMessage.target.sessionKey =
+							'agent-session:["echo","other","default","default"]';
+					if (condition === 'stale-attempt')
+						input.abandonedMessage.before = { submissionId: 'next', attemptId: 'replaced' };
+					if (condition === 'stale-producer')
+						await stream.acquireProducer(input.path, 'new-producer');
+					if (condition === 'sequence-gap') input.producerSequence += 1;
+					await expect(stream.append(input)).rejects.toThrow();
+				}
+				expect((await stream.read(input.path)).batches).toHaveLength(0);
+			});
+		}
 
 		it('creates one stream when exact identities race', async () => {
 			const { stream } = await create();

--- a/packages/runtime/vitest.config.ts
+++ b/packages/runtime/vitest.config.ts
@@ -1,0 +1,3 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({ test: { environment: 'node' } });


### PR DESCRIPTION
An earlier submission can leave an open assistant message behind a later conversation tail. If its dispatch row is settled but its stream settlement is unavailable, the next input still fails.

Before processing input, the writer now drains pending writes and clears only verified messages in the default conversation. A dedicated record identifies the conversation, submission, and message. It records cleanup now without inventing an old outcome or attempt.

The append transaction checks the earlier unjoined dispatch, its sequence and settlement time, the current attempt, and the agent/session match. It keeps ordinary attempt checks and producer checks. It rejects mixed batches and changed targets. The reducer preserves completed entries, raw history, tool results, and the active tail. No tool runs, and the old submission row stays unchanged.

SQLite, libSQL/Postgres/MySQL, MongoDB, and Redis implement the checks. Old custom adapters and the transient memory store refuse cleanup without the transaction capability.

**Reader compatibility:** The new record uses version 2; fold checkpoints use version 3. New readers replay old records. Old readers reject cleanup records. Stop old raw-record readers before starting this version against shared storage. The existing client reset chunk carries the corrected snapshot. No database reset or format-stamp change occurs.

Validation:

- Full repository build and type checks: 110/110 tasks pass.
- Runtime/SQLite: 41 tests pass. libSQL, private Redis 8, and private MongoDB 8 replica set: 32 tests pass each.
- Tests cover two attempts, fresh reads, retry, input ordering, append failure, stale attempts, foreign sessions, and retained history/tool results.
- Changed TypeScript files pass lint; one warning remains in an unchanged reducer line.
- `pnpm check` reaches existing Knip listings: 46 unused dependencies, 28 exports, and 2 types. The full check is not green.
- Native Postgres/MySQL servers and Cloudflare execution are not tested here. Their builds and type checks pass.
- One complete session staff review is done; all change findings are fixed.

Tracking: RUN-7628. This PR has separate changes from PR672 and the RUN-7631 attempt-change events. Package publication and Runner adoption are separate work.
