### PR TITLE
fix(runtime): commit local note acknowledgments with start signals

### DIFF
--- a/apps/docs/src/content/docs/reference/agent-hooks-api.md
+++ b/apps/docs/src/content/docs/reference/agent-hooks-api.md
@@ -273,8 +273,17 @@ Declare a named, client-facing data part and get back a write-only function that
 ```ts
 function useAgentStart(run: (ctx: AgentStartContext) => void | Promise<void>): void;
 
+interface LocalQueueAcknowledgment {
+  readonly table: string;
+  readonly key: Readonly<Record<string, string | number | null>>;
+}
+
+interface AgentStartAppendOptions {
+  readonly acknowledge?: LocalQueueAcknowledgment;
+}
+
 interface AgentStartContext {
-  readonly append: (message: AgentAppendMessage) => void;
+  readonly append: (message: AgentAppendMessage, options?: AgentStartAppendOptions) => void;
   readonly harness: FlueHarness;
   readonly log: FlueLogger;
   readonly signal: AbortSignal;
@@ -289,6 +298,27 @@ Run a callback when the agent starts work on a delivered message — after the i
 - `ctx.append` writes a signal into this response **without** registering a delivery — no `useAgentStart` run of its own, no submission. It accepts the same [`AgentAppendMessage`](#useagentfinish) shape and validation as `useAgentFinish`'s `append`, and it is legal only during the callback's execution window; a captured reference throws afterwards. Prefer dispatching; reach for `append` only when a delivery is wrong.
 - `ctx.harness` is the [harness](/docs/reference/agent-api/#harness), materialized lazily on first access. `ctx.signal` is the submission's abort signal. `ctx.log` emits progress lines into the conversation stream; the model never sees them.
 - Compaction can eventually fold signals away — keep a callback's substance in durable state and files; a signal is the announcement, not the storage.
+
+### Acknowledge a local queued note
+
+Stage a row deletion with its signal when the queue uses the same local SQLite database as the conversation store:
+
+```ts
+useAgentStart(({ append }) => {
+  for (const note of readQueuedNotes()) {
+    append(
+      { kind: 'signal', type: 'queued_note', body: note.body },
+      { acknowledge: { table: 'app_notes', key: { note_id: note.id } } },
+    );
+  }
+});
+```
+
+`append` validates and copies the key. It does not delete the row. After every start callback succeeds, one transaction stores the signals, state writes, and `agent_start_run` marker, then deletes the queued rows. A callback, batch, or deletion failure leaves those writes and rows unchanged. Signals and deletions follow hook declaration order. A retry of a committed producer batch skips all deletions, so a later row that reuses a key remains queued.
+
+The table must be an application table in SQLite's `main` database. Table and column names use letters, digits, and underscores, and start with a letter or underscore. Table names starting with `flue_` or `sqlite_` are reserved. Key values use strings, finite numbers, or `null`. Each key must match exactly one row; a missing or non-unique match rolls back the batch. Include a row version in the key if another writer can replace a note before the transaction commits.
+
+The built-in Node and Cloudflare SQLite stores support this operation. Stores without the optional [local acknowledgment method](/docs/reference/data-persistence-api/#conversationstreamstore) reject it. It cannot acknowledge a remote queue, run an async callback, or confirm that the model acts on the note. Calls without `acknowledge` keep their existing behavior.
 
 ## `useAgentFinish()`
 

--- a/apps/docs/src/content/docs/reference/data-persistence-api.md
+++ b/apps/docs/src/content/docs/reference/data-persistence-api.md
@@ -154,6 +154,10 @@ interface ConversationStreamStore {
     submission?: { submissionId: string; attemptId: string };
     records: readonly ConversationRecord[];
   }): Promise<{ offset: string }>;
+  appendWithLocalAcknowledgments?(
+    input: ConversationStreamAppendInput,
+    acknowledgments: readonly LocalQueueAcknowledgment[],
+  ): Promise<{ offset: string }>;
   read(
     path: string,
     options?: { offset?: string; limit?: number },
@@ -175,6 +179,8 @@ interface ConversationStreamStore {
 - `getMeta` — the stream's identity, incarnation, head offset, and producer state, or `null` for an unknown path.
 - `subscribe` — register a process-local change listener for a path; returns an unsubscribe function. Notification is best-effort in-process fan-out, not a durable or cross-process signal.
 - `putFoldCheckpoint` / `getFoldCheckpoint` — optional fold-checkpoint capability: one durable serialized-fold snapshot per path, superseded on each write, so loads fold only the suffix appended since it instead of replaying the stream from the origin. A checkpoint is a cache over the log, never authoritative — the runtime validates its format version, incarnation, and offset on load and silently rebuilds by replay when anything mismatches. Adapters without the pair stay fully functional; the runtime degrades to full replay and warns once per path. Implementations must be torn-write safe: a partially persisted checkpoint must read back as absent or fail the read, never as a plausible blob. `getFoldCheckpoint` with `atOrBefore` returns the checkpoint only when its offset is at or before the bound.
+
+`ConversationStreamAppendInput` is the input type of `append`. The optional `appendWithLocalAcknowledgments` method takes the same input and application queue row keys. It must commit each deletion in the same local SQLite transaction as a new batch. A failure rolls back the entire transaction. It must preserve producer and submission checks and skip deletions when returning an already committed batch. The runtime refuses acknowledgments when the method is absent. The built-in Node and Cloudflare SQLite stores provide it; the memory and async SQL stores do not. See the [start-hook API](/docs/reference/agent-hooks-api/#acknowledge-a-local-queued-note) for key validation and use.
 
 Offsets are opaque strings ordered by the stream; `formatOffset` and `parseOffset` convert between offset strings and integer sequence numbers. `defineSqlConversationStreamStore(dialect: SqlConversationDialect)` builds a complete `ConversationStreamStore` over an async SQL backend — the Postgres, libSQL, and MySQL adapters share one fence implementation and differ only in dialect constants. `InMemoryConversationStreamStore` and `StreamListenerRegistry` are exported as reference building blocks.
 

--- a/packages/runtime/src/adapter.ts
+++ b/packages/runtime/src/adapter.ts
@@ -101,6 +101,7 @@ export type {
 	ConversationRecord,
 	SubmissionSettledRecord,
 } from './conversation-records.ts';
+export type { LocalQueueAcknowledgment } from './local-queue-acknowledgment.ts';
 export type {
 	AttachmentStore,
 	GetAttachmentInput,
@@ -118,6 +119,7 @@ export {
 export type {
 	ConversationFoldCheckpoint,
 	ConversationProducerClaim,
+	ConversationStreamAppendInput,
 	ConversationStreamBatch,
 	ConversationStreamIdentity,
 	ConversationStreamMeta,

--- a/packages/runtime/src/conversation-writer.ts
+++ b/packages/runtime/src/conversation-writer.ts
@@ -7,6 +7,7 @@ import type {
 } from './conversation-records.ts';
 import type { IndexedConversationRecord, ReducedInstanceState } from './conversation-reducer.ts';
 import { conversationScopeKey, reduceConversationRecords } from './conversation-reducer.ts';
+import type { LocalQueueAcknowledgment } from './local-queue-acknowledgment.ts';
 import type {
 	ConversationProducerClaim,
 	ConversationStreamIdentity,
@@ -147,6 +148,14 @@ export class ConversationRecordWriter {
 		}
 	}
 
+	appendWithLocalAcknowledgments(
+		records: readonly ConversationRecord[],
+		acknowledgments: readonly LocalQueueAcknowledgment[],
+		options: ConversationAppendOptions = {},
+	): Promise<{ offset: string }> {
+		return this.appendBatch(records, options, acknowledgments);
+	}
+
 	enqueue(
 		records: readonly ConversationRecord[],
 		options: ConversationAppendOptions = {},
@@ -225,6 +234,7 @@ export class ConversationRecordWriter {
 	private appendBatch(
 		records: readonly ConversationRecord[],
 		options: ConversationAppendOptions,
+		acknowledgments: readonly LocalQueueAcknowledgment[] = [],
 	): Promise<{ offset: string }> {
 		const operation = this.tail.then(async () => {
 			this.assertActive();
@@ -246,12 +256,21 @@ export class ConversationRecordWriter {
 				records,
 			};
 			try {
+				const append = () => {
+					if (acknowledgments.length === 0) return this.store.append(input);
+					if (!this.store.appendWithLocalAcknowledgments) {
+						throw new Error(
+							'[flue] This conversation store does not support atomic local acknowledgments.',
+						);
+					}
+					return this.store.appendWithLocalAcknowledgments(input, acknowledgments);
+				};
 				let result: { offset: string };
 				try {
-					result = await this.store.append(input);
+					result = await append();
 				} catch (firstError) {
 					try {
-						result = await this.store.append(input);
+						result = await append();
 					} catch {
 						throw firstError;
 					}

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -75,6 +75,7 @@ export { defineSubagent, GeneralSubagent, useSubagent } from './hooks/use-subage
 export { useTool } from './hooks/use-tool.ts';
 export { type FlueInstrumentation, instrument } from './instrumentation.ts';
 export type { JsonValue } from './json-snapshot.ts';
+export type { LocalQueueAcknowledgment } from './local-queue-acknowledgment.ts';
 export type { McpAuth, McpConnection, McpConnectionDefinition, McpTransport } from './mcp.ts';
 export { createMcpConnection } from './mcp.ts';
 export type {
@@ -82,6 +83,7 @@ export type {
 	AgentFinishContext,
 	AgentResponseToolCall,
 	AgentSignalAppend,
+	AgentStartAppendOptions,
 	AgentStartContext,
 	ResponseFinishContext,
 	ResponseMetadataCallback,

--- a/packages/runtime/src/local-queue-acknowledgment.ts
+++ b/packages/runtime/src/local-queue-acknowledgment.ts
@@ -1,0 +1,62 @@
+import * as v from 'valibot';
+import type { SqlStorage } from './sql-storage.ts';
+
+/** One application queue row in the conversation store's local SQLite database. */
+export interface LocalQueueAcknowledgment {
+	readonly table: string;
+	readonly key: Readonly<Record<string, string | number | null>>;
+}
+
+const IdentifierSchema = v.pipe(v.string(), v.regex(/^[A-Za-z_][A-Za-z0-9_]*$/));
+const AcknowledgmentSchema = v.strictObject({
+	table: v.pipe(
+		IdentifierSchema,
+		v.check((name) => !/^(flue_|sqlite_)/i.test(name)),
+	),
+	// A record schema drops keys such as "constructor". Every column must constrain the deletion.
+	key: v.pipe(
+		v.custom<Record<string, unknown>>(
+			(key) => typeof key === 'object' && key !== null && !Array.isArray(key),
+		),
+		v.transform((key) => Object.entries(key)),
+		v.array(
+			v.tuple([IdentifierSchema, v.union([v.string(), v.pipe(v.number(), v.finite()), v.null()])]),
+		),
+		v.minLength(1),
+		v.transform((entries): LocalQueueAcknowledgment['key'] => Object.fromEntries(entries)),
+	),
+});
+
+/** Validate and copy at staging time, before the caller can change the key. */
+export function assertLocalQueueAcknowledgment(value: unknown): LocalQueueAcknowledgment {
+	const parsed = v.safeParse(AcknowledgmentSchema, value);
+	if (!parsed.success) {
+		throw new Error(
+			'[flue] A local acknowledgment requires an application table and a non-empty row key. ' +
+				'Use simple SQL names and string, finite number, or null key values. ' +
+				'Tables starting with flue_ or sqlite_ are reserved.',
+		);
+	}
+	return parsed.output;
+}
+
+/** Call only inside the transaction that inserts a new conversation batch. */
+export function applyLocalQueueAcknowledgments(
+	sql: SqlStorage,
+	acknowledgments: readonly LocalQueueAcknowledgment[],
+): void {
+	for (const acknowledgment of acknowledgments) {
+		const { table, key } = assertLocalQueueAcknowledgment(acknowledgment);
+		const entries = Object.entries(key);
+		const predicate = entries.map(([column]) => `"${table}"."${column}" IS ?`).join(' AND ');
+		const rows = sql
+			.exec(
+				`DELETE FROM main."${table}" WHERE ${predicate} RETURNING 1`,
+				...entries.map(([, value]) => value),
+			)
+			.toArray();
+		if (rows.length !== 1) {
+			throw new Error('[flue] A local acknowledgment must match exactly one queued row.');
+		}
+	}
+}

--- a/packages/runtime/src/message-output.ts
+++ b/packages/runtime/src/message-output.ts
@@ -1,5 +1,6 @@
 import * as v from 'valibot';
 import { RESERVED_SIGNAL_TYPES } from './conversation-records.ts';
+import type { LocalQueueAcknowledgment } from './local-queue-acknowledgment.ts';
 import type { FlueHarness, FlueLogger, PromptUsage } from './types.ts';
 
 /**
@@ -142,6 +143,11 @@ export function assertAppendMessage(message: unknown): AgentSignalAppend {
 	};
 }
 
+export interface AgentStartAppendOptions {
+	/** Delete this row only when this delivery's signals, state, and start marker commit. */
+	readonly acknowledge?: LocalQueueAcknowledgment;
+}
+
 /**
  * The context a `useAgentStart` callback receives. `log` emits progress lines
  * into the conversation stream (the model never sees them); `signal` is the
@@ -157,7 +163,7 @@ export function assertAppendMessage(message: unknown): AgentSignalAppend {
  * Prefer dispatching; reach for `append` only when a delivery is wrong.
  */
 export interface AgentStartContext {
-	readonly append: (message: AgentAppendMessage) => void;
+	readonly append: (message: AgentAppendMessage, options?: AgentStartAppendOptions) => void;
 	readonly harness: FlueHarness;
 	readonly log: FlueLogger;
 	readonly signal: AbortSignal;

--- a/packages/runtime/src/runtime/conversation-stream-store.ts
+++ b/packages/runtime/src/runtime/conversation-stream-store.ts
@@ -3,6 +3,10 @@ import type { AgentSubmissionStore } from '../agent-execution-store.ts';
 import type { ConversationRecord } from '../conversation-records.ts';
 import { ConversationStreamStoreError } from '../errors.ts';
 import { migrateFlueSqlSchema } from '../format-version.ts';
+import {
+	applyLocalQueueAcknowledgments,
+	type LocalQueueAcknowledgment,
+} from '../local-queue-acknowledgment.ts';
 import { parseSessionStorageKey } from '../session-identity.ts';
 import type { SqlStorage } from '../sql-storage.ts';
 import { generateIncarnationId } from './ids.ts';
@@ -60,6 +64,16 @@ export interface ConversationFoldCheckpoint {
 	data: string;
 }
 
+export interface ConversationStreamAppendInput {
+	path: string;
+	producerId: string;
+	producerEpoch: number;
+	incarnation: string;
+	producerSequence: number;
+	submission?: { submissionId: string; attemptId: string };
+	records: readonly ConversationRecord[];
+}
+
 export interface ConversationStreamStore {
 	createStream(path: string, identity: ConversationStreamIdentity): Promise<void>;
 	acquireProducer(path: string, producerId: string): Promise<ConversationProducerClaim>;
@@ -79,15 +93,16 @@ export interface ConversationStreamStore {
 	 * size; a custom adapter that splits records across non-atomic writes
 	 * violates the contract.
 	 */
-	append(input: {
-		path: string;
-		producerId: string;
-		producerEpoch: number;
-		incarnation: string;
-		producerSequence: number;
-		submission?: { submissionId: string; attemptId: string };
-		records: readonly ConversationRecord[];
-	}): Promise<{ offset: string }>;
+	append(input: ConversationStreamAppendInput): Promise<{ offset: string }>;
+	/**
+	 * Commit local queue deletions in the same transaction as a new batch.
+	 * A failure rolls back both. A committed batch replay skips the deletions.
+	 * Stores without this capability must omit it; the writer rejects its use.
+	 */
+	appendWithLocalAcknowledgments?(
+		input: ConversationStreamAppendInput,
+		acknowledgments: readonly LocalQueueAcknowledgment[],
+	): Promise<{ offset: string }>;
 	read(
 		path: string,
 		options?: { offset?: string; limit?: number },
@@ -608,15 +623,21 @@ export class SqliteConversationStreamStore implements ConversationStreamStore {
 		});
 	}
 
-	async append(input: {
-		path: string;
-		producerId: string;
-		producerEpoch: number;
-		incarnation: string;
-		producerSequence: number;
-		submission?: { submissionId: string; attemptId: string };
-		records: readonly ConversationRecord[];
-	}): Promise<{ offset: string }> {
+	append(input: ConversationStreamAppendInput): Promise<{ offset: string }> {
+		return this.appendBatch(input, []);
+	}
+
+	appendWithLocalAcknowledgments(
+		input: ConversationStreamAppendInput,
+		acknowledgments: readonly LocalQueueAcknowledgment[],
+	): Promise<{ offset: string }> {
+		return this.appendBatch(input, acknowledgments);
+	}
+
+	private async appendBatch(
+		input: ConversationStreamAppendInput,
+		acknowledgments: readonly LocalQueueAcknowledgment[],
+	): Promise<{ offset: string }> {
 		if (input.records.length === 0)
 			this.fail('append', input.path, 'A canonical batch cannot be empty.');
 		const data = JSON.stringify(input.records);
@@ -693,6 +714,7 @@ export class SqliteConversationStreamStore implements ConversationStreamStore {
 				 WHERE path = ?`,
 				input.path,
 			);
+			applyLocalQueueAcknowledgments(this.sql, acknowledgments);
 			return { offset: formatOffset(seq), appended: true };
 		});
 		if (result.appended) this.listeners.notify(input.path);

--- a/packages/runtime/src/session-start-acknowledgment.test.ts
+++ b/packages/runtime/src/session-start-acknowledgment.test.ts
@@ -1,0 +1,571 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+import { fauxAssistantMessage, fauxProvider } from '@earendil-works/pi-ai';
+import { afterEach, describe, expect, it } from 'vitest';
+import { init } from './agent-client.ts';
+import type { PersistenceAdapter } from './agent-execution-store.ts';
+import type { ConversationRecord } from './conversation-records.ts';
+import { ConversationRecordWriter } from './conversation-writer.ts';
+import { useAgentStart } from './hooks/use-agent-start.ts';
+import { useDelivery } from './hooks/use-delivery.ts';
+import { useModel } from './hooks/use-model.ts';
+import { usePersistentState } from './hooks/use-persistent-state.ts';
+import {
+	assertLocalQueueAcknowledgment,
+	type LocalQueueAcknowledgment,
+} from './local-queue-acknowledgment.ts';
+import { sqlite } from './node/agent-execution-store.ts';
+import { assembleNodeAgentRuntime } from './node/assemble.ts';
+import { type Flue, start } from './node/start.ts';
+import { InMemoryConversationStreamStore } from './runtime/conversation-stream-store.ts';
+import { setProvider } from './runtime/providers.ts';
+import { agentStreamPath } from './runtime/stream-offsets.ts';
+import type { Agent, DispatchReceipt } from './types.ts';
+
+const cleanups: Array<() => void | Promise<void>> = [];
+let runtime: Pick<Flue, 'stop'> | undefined;
+
+afterEach(async () => {
+	try {
+		await runtime?.stop();
+	} finally {
+		runtime = undefined;
+		for (const cleanup of cleanups.splice(0).reverse()) await cleanup();
+	}
+});
+
+async function database() {
+	const directory = mkdtempSync(join(tmpdir(), 'flue-start-ack-'));
+	cleanups.push(() => rmSync(directory, { recursive: true, force: true }));
+	const path = join(directory, 'agent.sqlite');
+	const db = new DatabaseSync(path);
+	cleanups.push(() => db.close());
+	db.exec('CREATE TABLE app_notes (note_key TEXT PRIMARY KEY, body TEXT NOT NULL)');
+	const adapter = sqlite(path);
+	cleanups.push(() => adapter.close?.());
+	await adapter.migrate?.();
+	const stores = await adapter.connect();
+	const stream = stores.conversationStreamStore;
+	const appendAcknowledged = stream.appendWithLocalAcknowledgments?.bind(stream);
+	if (!appendAcknowledged) throw new Error('The SQLite store must support local acknowledgments.');
+	return {
+		path,
+		db,
+		adapter,
+		stores,
+		stream,
+		appendAcknowledged,
+		queue(key: string, body = key) {
+			db.prepare('INSERT INTO app_notes (note_key, body) VALUES (?, ?)').run(key, body);
+		},
+		queued() {
+			return db.prepare('SELECT note_key, body FROM app_notes ORDER BY note_key').all();
+		},
+		async records(agentName = 'Notes') {
+			const result = await stream.read(agentStreamPath(agentName, 'test'), { limit: 1000 });
+			return result.batches.flatMap((batch) => batch.records);
+		},
+	};
+}
+
+function acknowledgment(key: string) {
+	return { table: 'app_notes', key: { note_key: key } };
+}
+
+function provider() {
+	return fauxProvider({ provider: 'ack-test', models: [{ id: 'notes' }] });
+}
+
+async function startCoordinator(
+	agent: Agent,
+	adapter: PersistenceAdapter,
+	faux: ReturnType<typeof provider>,
+) {
+	setProvider(faux.provider);
+	const assembled = await assembleNodeAgentRuntime({
+		agents: [{ identity: 'Notes', agent }],
+		adapter,
+		stores: await adapter.connect(),
+	});
+	runtime = { stop: () => assembled.close() };
+	return assembled.coordinator;
+}
+
+describe('start hook local acknowledgments', () => {
+	it('commits in declaration order and retains a reused key after restart', async () => {
+		const fixture = await database();
+		fixture.queue('first');
+		fixture.queue('second');
+		fixture.db.exec(`
+			CREATE TABLE note_deletions (sequence INTEGER PRIMARY KEY, note_key TEXT);
+			CREATE TRIGGER record_note_deletion AFTER DELETE ON app_notes
+			BEGIN INSERT INTO note_deletions (note_key) VALUES (OLD.note_key); END;
+		`);
+		const secondStaged = Promise.withResolvers<void>();
+		const calls = [0, 0];
+		const faux = provider();
+		faux.setResponses([fauxAssistantMessage('done')]);
+		function Notes() {
+			useModel('ack-test/notes');
+			const [, setCount] = usePersistentState('count', 0);
+			useAgentStart(async ({ append }) => {
+				calls[0] = (calls[0] ?? 0) + 1;
+				await secondStaged.promise;
+				const key = acknowledgment('first');
+				append({ kind: 'signal', type: 'note', body: 'first' }, { acknowledge: key });
+				key.key.note_key = 'second';
+				setCount(1);
+				expect(fixture.queued()).toHaveLength(2);
+			});
+			useAgentStart(({ append }) => {
+				calls[1] = (calls[1] ?? 0) + 1;
+				append(
+					{ kind: 'signal', type: 'note', body: 'second' },
+					{ acknowledge: acknowledgment('second') },
+				);
+				secondStaged.resolve();
+			});
+			return 'Read the notes.';
+		}
+		runtime = await start({ agents: [Notes], db: fixture.adapter, providers: [faux.provider] });
+		const handle = init(Notes, { id: 'test' });
+		const receipt = await handle.dispatch('start');
+		expect((await handle.read(receipt)).text).toBe('done');
+		expect(calls).toEqual([1, 1]);
+		expect(faux.state.callCount).toBe(1);
+		expect(fixture.queued()).toEqual([]);
+		expect(
+			fixture.db.prepare('SELECT note_key FROM note_deletions ORDER BY sequence').all(),
+		).toEqual([{ note_key: 'first' }, { note_key: 'second' }]);
+		const { batches } = await fixture.stream.read(agentStreamPath('Notes', 'test'));
+		const startBatches = batches.filter((batch) =>
+			batch.records.some((record) => record.type === 'agent_start_run'),
+		);
+		expect(startBatches).toHaveLength(1);
+		expect(startBatches[0]?.records.map((record) => record.type)).toEqual([
+			'signal',
+			'signal',
+			'state_write',
+			'agent_start_run',
+		]);
+		const signals = startBatches[0]?.records.filter((record) => record.type === 'signal');
+		expect(signals?.map((record) => record.content)).toEqual(['first', 'second']);
+		expect(signals?.[1]?.parentId).toBe(signals?.[0]?.messageId);
+		expect(startBatches[0]?.records[2]).toMatchObject({ name: 'count', value: 1 });
+		await runtime.stop();
+		runtime = undefined;
+		fixture.queue('first', 'later note');
+		runtime = await start({
+			agents: [Notes],
+			db: sqlite(fixture.path),
+			providers: [faux.provider],
+		});
+		expect((await init(Notes, { id: 'test' }).read(receipt)).text).toBe('done');
+		expect(calls).toEqual([1, 1]);
+		expect(faux.state.callCount).toBe(1);
+		expect(fixture.queued()).toEqual([{ note_key: 'first', body: 'later note' }]);
+	});
+
+	it.each(['later hook', 'batch', 'acknowledgment'] as const)(
+		'keeps queued rows and start output unchanged when the %s fails',
+		async (failure) => {
+			const fixture = await database();
+			fixture.queue('first');
+			fixture.queue('second');
+			if (failure === 'batch') {
+				fixture.db.exec(`
+					CREATE TRIGGER reject_start BEFORE INSERT ON flue_conversation_stream_batches
+					WHEN EXISTS (
+						SELECT 1 FROM json_each(NEW.data) WHERE json_extract(value, '$.type') = 'agent_start_run'
+					)
+					BEGIN SELECT RAISE(ABORT, 'start batch refused'); END
+				`);
+			}
+			if (failure === 'acknowledgment') {
+				fixture.db.exec(`
+					CREATE TRIGGER reject_ack BEFORE DELETE ON app_notes
+					WHEN OLD.note_key = 'second'
+					BEGIN SELECT RAISE(ABORT, 'ack refused'); END
+				`);
+			}
+			const calls = [0, 0];
+			const firstStaged = Promise.withResolvers<void>();
+			const faux = provider();
+			function Notes() {
+				useModel('ack-test/notes');
+				const [, setCount] = usePersistentState('count', 0);
+				useAgentStart(({ append }) => {
+					calls[0] = (calls[0] ?? 0) + 1;
+					for (const key of ['first', 'second']) {
+						append(
+							{ kind: 'signal', type: 'note', body: key },
+							{ acknowledge: acknowledgment(key) },
+						);
+					}
+					setCount(1);
+					expect(fixture.queued()).toHaveLength(2);
+					firstStaged.resolve();
+				});
+				useAgentStart(async () => {
+					calls[1] = (calls[1] ?? 0) + 1;
+					await firstStaged.promise;
+					if (failure === 'later hook') throw new Error('later hook refused');
+				});
+				return 'Read the notes.';
+			}
+			const coordinator = await startCoordinator(Notes, fixture.adapter, faux);
+			const handle = init(Notes, { id: 'test' });
+			const receipt = await handle.dispatch('start');
+			await coordinator.waitForIdle();
+			expect(
+				(await fixture.stores.submissionStore.getSubmission(receipt.submissionId))?.attemptCount,
+			).toBe(1);
+			expect(calls).toEqual([1, 1]);
+			expect(faux.state.callCount).toBe(0);
+			expect(fixture.queued()).toEqual([
+				{ note_key: 'first', body: 'first' },
+				{ note_key: 'second', body: 'second' },
+			]);
+			const records = await fixture.records();
+			expect(records.filter((record) => record.type === 'agent_start_run')).toEqual([]);
+			expect(records.filter((record) => record.type === 'state_write')).toEqual([]);
+			expect(
+				records.filter((record) => record.type === 'signal' && record.signalType === 'note'),
+			).toEqual([]);
+		},
+	);
+
+	it('acknowledges a joined delivery without an extra delivery or model call', async () => {
+		const fixture = await database();
+		const firstTurn = Promise.withResolvers<void>();
+		const releaseTurn = Promise.withResolvers<void>();
+		const faux = provider();
+		faux.setResponses([
+			async () => {
+				firstTurn.resolve();
+				await releaseTurn.promise;
+				return fauxAssistantMessage('first reply');
+			},
+			fauxAssistantMessage('joined reply'),
+		]);
+		const deliveries: string[] = [];
+		function Notes() {
+			useModel('ack-test/notes');
+			const delivery = useDelivery();
+			useAgentStart(({ append }) => {
+				deliveries.push(delivery.body);
+				if (delivery.body !== 'joined') return;
+				append(
+					{ kind: 'signal', type: 'note', body: 'joined note' },
+					{ acknowledge: acknowledgment('joined') },
+				);
+			});
+			return 'Read the notes.';
+		}
+		runtime = await start({ agents: [Notes], db: fixture.adapter, providers: [faux.provider] });
+		const handle = init(Notes, { id: 'test' });
+		const host = await handle.dispatch('host');
+		await firstTurn.promise;
+		let joined: DispatchReceipt;
+		try {
+			fixture.queue('joined');
+			joined = await handle.dispatch('joined');
+		} finally {
+			releaseTurn.resolve();
+		}
+		expect((await handle.read(host)).text).toBe('first reply\n\njoined reply');
+		expect((await handle.read(joined)).text).toBe('first reply\n\njoined reply');
+		expect(deliveries).toEqual(['host', 'joined']);
+		expect(faux.state.callCount).toBe(2);
+		expect(fixture.queued()).toEqual([]);
+		const records = await fixture.records();
+		expect(
+			records
+				.filter((record) => record.type === 'agent_start_run')
+				.map((record) => record.submissionId),
+		).toEqual([host.submissionId, joined.submissionId]);
+		const notes = records.filter(
+			(record) => record.type === 'signal' && record.signalType === 'note',
+		);
+		expect(notes).toHaveLength(1);
+		expect(notes[0]).toMatchObject({ submissionId: host.submissionId, content: 'joined note' });
+	});
+
+	it.each([false, true])(
+		'handles a store without the capability (acknowledge: %s)',
+		async (acknowledge) => {
+			const fixture = await database();
+			fixture.queue('first');
+			const stream = fixture.stream;
+			const adapter: PersistenceAdapter = {
+				connect: () => ({
+					...fixture.stores,
+					conversationStreamStore: {
+						createStream: stream.createStream.bind(stream),
+						acquireProducer: stream.acquireProducer.bind(stream),
+						append: stream.append.bind(stream),
+						read: stream.read.bind(stream),
+						getMeta: stream.getMeta.bind(stream),
+						subscribe: stream.subscribe.bind(stream),
+					},
+				}),
+			};
+			const faux = provider();
+			faux.setResponses([fauxAssistantMessage('done')]);
+			let calls = 0;
+			function Notes() {
+				useModel('ack-test/notes');
+				useAgentStart(({ append }) => {
+					calls += 1;
+					append(
+						{ kind: 'signal', type: 'note', body: 'first' },
+						acknowledge ? { acknowledge: acknowledgment('first') } : undefined,
+					);
+				});
+				return 'Read the note.';
+			}
+			const coordinator = await startCoordinator(Notes, adapter, faux);
+			const handle = init(Notes, { id: 'test' });
+			const receipt = await handle.dispatch('start');
+			await coordinator.waitForIdle();
+			if (!acknowledge) {
+				expect((await handle.read(receipt)).text).toBe('done');
+			}
+			expect(calls).toBe(1);
+			expect(faux.state.callCount).toBe(acknowledge ? 0 : 1);
+			expect(fixture.queued()).toEqual([{ note_key: 'first', body: 'first' }]);
+			const records = await fixture.records();
+			expect(records.filter((record) => record.type === 'agent_start_run')).toHaveLength(
+				acknowledge ? 0 : 1,
+			);
+			expect(
+				records.filter((record) => record.type === 'signal' && record.signalType === 'note'),
+			).toHaveLength(acknowledge ? 0 : 1);
+		},
+	);
+});
+
+function signalRecord(): ConversationRecord {
+	return {
+		v: 1,
+		id: 'note-record',
+		type: 'signal',
+		timestamp: '2026-09-12T00:00:00.000Z',
+		conversationId: 'conversation',
+		harness: 'default',
+		session: 'default',
+		messageId: 'note-message',
+		parentId: null,
+		signalType: 'note',
+		content: 'first',
+	};
+}
+
+describe('local acknowledgment transaction and replay', () => {
+	it.each(['constructor', 'prototype', '__proto__'])(
+		'preserves the %s column in a row key',
+		async (column) => {
+			const fixture = await database();
+			fixture.db.exec(`CREATE TABLE app_versions (id INTEGER PRIMARY KEY, "${column}" TEXT)`);
+			fixture.db.prepare('INSERT INTO app_versions VALUES (?, ?)').run(1, 'current');
+			const path = agentStreamPath('Notes', 'test');
+			await fixture.stream.createStream(path, { agentName: 'Notes', instanceId: 'test' });
+			const claim = await fixture.stream.acquireProducer(path, 'producer');
+			const input = { ...claim, path, producerSequence: 0, records: [signalRecord()] };
+			const key = { id: 1, [column]: 'stale' };
+			await expect(
+				fixture.appendAcknowledged(input, [{ table: 'app_versions', key }]),
+			).rejects.toThrow('exactly one');
+			expect(fixture.db.prepare('SELECT id FROM app_versions').all()).toEqual([{ id: 1 }]);
+			expect((await fixture.stream.read(path)).batches).toEqual([]);
+			key[column] = 'current';
+			await fixture.appendAcknowledged(input, [{ table: 'app_versions', key }]);
+			expect(fixture.db.prepare('SELECT id FROM app_versions').all()).toEqual([]);
+			expect((await fixture.stream.read(path)).batches).toHaveLength(1);
+		},
+	);
+
+	it('returns a committed batch after reopening without acknowledging a reused key', async () => {
+		const fixture = await database();
+		fixture.queue('first');
+		const path = agentStreamPath('Notes', 'test');
+		await fixture.stream.createStream(path, { agentName: 'Notes', instanceId: 'test' });
+		const claim = await fixture.stream.acquireProducer(path, 'producer');
+		const input = { ...claim, path, producerSequence: 0, records: [signalRecord()] };
+		const committed = await fixture.appendAcknowledged(input, [acknowledgment('first')]);
+		await fixture.adapter.close?.();
+		fixture.queue('first', 'after restart');
+		const reopened = sqlite(fixture.path);
+		cleanups.push(() => reopened.close?.());
+		const { conversationStreamStore: stream } = await reopened.connect();
+		if (!stream.appendWithLocalAcknowledgments)
+			throw new Error('Missing local acknowledgment method.');
+		expect(await stream.appendWithLocalAcknowledgments(input, [acknowledgment('first')])).toEqual(
+			committed,
+		);
+		expect(fixture.queued()).toEqual([{ note_key: 'first', body: 'after restart' }]);
+		expect((await stream.read(path)).batches).toHaveLength(1);
+	});
+
+	it('preserves the submission attempt check before applying an acknowledgment', async () => {
+		const fixture = await database();
+		fixture.queue('first');
+		const path = agentStreamPath('Notes', 'test');
+		const { submissionStore } = fixture.stores;
+		await submissionStore.admitDirect({
+			kind: 'direct',
+			agent: 'Notes',
+			id: 'test',
+			submissionId: 'submission',
+			message: { kind: 'user', body: 'start' },
+			acceptedAt: '2026-09-12T00:00:00.000Z',
+		});
+		await submissionStore.markSubmissionCanonicalReady('submission');
+		await submissionStore.claimSubmission({
+			submissionId: 'submission',
+			attemptId: 'current',
+			ownerId: 'producer',
+			leaseExpiresAt: Date.now() + 30_000,
+		});
+		await fixture.stream.createStream(path, { agentName: 'Notes', instanceId: 'test' });
+		const claim = await fixture.stream.acquireProducer(path, 'producer');
+		await expect(
+			fixture.appendAcknowledged(
+				{
+					...claim,
+					path,
+					producerSequence: 0,
+					submission: { submissionId: 'submission', attemptId: 'stale' },
+					records: [{ ...signalRecord(), submissionId: 'submission', attemptId: 'stale' }],
+				},
+				[acknowledgment('first')],
+			),
+		).rejects.toThrow();
+		expect(fixture.queued()).toHaveLength(1);
+		expect((await fixture.stream.read(path)).batches).toEqual([]);
+		expect((await fixture.stream.getMeta(path))?.nextProducerSequence).toBe(0);
+	});
+
+	it('binds string, number, and null values in a composite row key', async () => {
+		const fixture = await database();
+		fixture.db.exec('CREATE TABLE app_composite (id INTEGER PRIMARY KEY, scope TEXT, body TEXT)');
+		const body = '"; DELETE FROM app_composite; --';
+		fixture.db.prepare('INSERT INTO app_composite VALUES (?, ?, ?)').run(1, null, body);
+		fixture.db.prepare('INSERT INTO app_composite VALUES (?, ?, ?)').run(2, null, body);
+		const path = agentStreamPath('Notes', 'test');
+		await fixture.stream.createStream(path, { agentName: 'Notes', instanceId: 'test' });
+		const claim = await fixture.stream.acquireProducer(path, 'producer');
+		await fixture.appendAcknowledged(
+			{ ...claim, path, producerSequence: 0, records: [signalRecord()] },
+			[{ table: 'app_composite', key: { id: 1, scope: null, body } }],
+		);
+		expect(fixture.db.prepare('SELECT id FROM app_composite').all()).toEqual([{ id: 2 }]);
+		expect((await fixture.stream.read(path)).batches).toHaveLength(1);
+	});
+
+	it('retries a lost commit response without deleting a later row with the same key', async () => {
+		const fixture = await database();
+		fixture.queue('first');
+		let attempts = 0;
+		const stream = fixture.stream;
+		const store = {
+			createStream: stream.createStream.bind(stream),
+			acquireProducer: stream.acquireProducer.bind(stream),
+			append: stream.append.bind(stream),
+			read: stream.read.bind(stream),
+			getMeta: stream.getMeta.bind(stream),
+			subscribe: stream.subscribe.bind(stream),
+			async appendWithLocalAcknowledgments(...args: Parameters<typeof fixture.appendAcknowledged>) {
+				attempts += 1;
+				const result = await fixture.appendAcknowledged(...args);
+				if (attempts === 1) {
+					fixture.queue('first', 'later note');
+					throw new Error('commit response lost');
+				}
+				return result;
+			},
+		};
+		const path = agentStreamPath('Notes', 'test');
+		const writer = await ConversationRecordWriter.create({
+			store,
+			path,
+			identity: { agentName: 'Notes', instanceId: 'test' },
+			producerId: 'producer',
+		});
+		await writer.appendWithLocalAcknowledgments([signalRecord()], [acknowledgment('first')]);
+		expect(attempts).toBe(2);
+		expect(fixture.queued()).toEqual([{ note_key: 'first', body: 'later note' }]);
+		expect((await stream.read(path)).batches.map((batch) => batch.records)).toEqual([
+			[signalRecord()],
+		]);
+		expect((await stream.getMeta(path))?.nextProducerSequence).toBe(1);
+	});
+
+	it('rolls back the batch when a key does not select exactly one row', async () => {
+		const fixture = await database();
+		fixture.queue('first', 'shared');
+		fixture.queue('second', 'shared');
+		const path = agentStreamPath('Notes', 'test');
+		await fixture.stream.createStream(path, { agentName: 'Notes', instanceId: 'test' });
+		const claim = await fixture.stream.acquireProducer(path, 'producer');
+		const input = { ...claim, path, producerSequence: 0, records: [signalRecord()] };
+		const keys: LocalQueueAcknowledgment['key'][] = [{ note_key: 'missing' }, { body: 'shared' }];
+		for (const key of keys) {
+			await expect(
+				fixture.appendAcknowledged(input, [{ table: 'app_notes', key }]),
+			).rejects.toThrow('exactly one');
+			expect(fixture.queued()).toHaveLength(2);
+			expect((await fixture.stream.read(path)).batches).toEqual([]);
+			expect((await fixture.stream.getMeta(path))?.nextProducerSequence).toBe(0);
+		}
+	});
+
+	it('rejects an acknowledgment with a stale producer before deleting the queue row', async () => {
+		const fixture = await database();
+		fixture.queue('first');
+		const path = agentStreamPath('Notes', 'test');
+		await fixture.stream.createStream(path, { agentName: 'Notes', instanceId: 'test' });
+		const claim = await fixture.stream.acquireProducer(path, 'producer');
+		await fixture.stream.acquireProducer(path, 'replacement');
+		await expect(
+			fixture.appendAcknowledged(
+				{ ...claim, path, producerSequence: 0, records: [signalRecord()] },
+				[acknowledgment('first')],
+			),
+		).rejects.toThrow();
+		expect(fixture.queued()).toHaveLength(1);
+		expect((await fixture.stream.read(path)).batches).toEqual([]);
+	});
+
+	it('refuses acknowledgments on the memory store without appending', async () => {
+		const store = new InMemoryConversationStreamStore();
+		const path = agentStreamPath('Notes', 'test');
+		const writer = await ConversationRecordWriter.create({
+			store,
+			path,
+			identity: { agentName: 'Notes', instanceId: 'test' },
+			producerId: 'producer',
+		});
+		await expect(
+			writer.appendWithLocalAcknowledgments([signalRecord()], [acknowledgment('first')]),
+		).rejects.toThrow('does not support atomic local acknowledgments');
+		expect((await store.read(path)).batches).toEqual([]);
+	});
+
+	it.each([
+		{ table: 'flue_conversation_streams', key: { path: 'x' } },
+		{ table: 'FLUE_records', key: { id: 1 } },
+		{ table: 'sqlite_schema', key: { name: 'x' } },
+		{ table: 'other.app_notes', key: { note_key: 'first' } },
+		{ table: 'app_notes"; DELETE FROM app_notes; --', key: { note_key: 'first' } },
+		{ table: 'app_notes', key: {} },
+		{ table: 'app_notes', key: { 'note_key OR 1=1': 'first' } },
+		{ table: 'app_notes', key: { note_key: Number.NaN } },
+		{ table: 'app_notes', key: { note_key: Promise.resolve('first') } },
+		async () => {},
+	])('rejects an invalid local acknowledgment: %j', (value) => {
+		expect(() => assertLocalQueueAcknowledgment(value)).toThrow('local acknowledgment requires');
+	});
+});

--- a/packages/runtime/src/session.ts
+++ b/packages/runtime/src/session.ts
@@ -110,6 +110,10 @@ import { type FlueExecutionContext, interceptExecution } from './execution-inter
 import { resolveSubagentDefinition } from './hooks/render.ts';
 import type { HookStateBuffer, HookStateWrite } from './hooks/use-persistent-state.ts';
 import {
+	assertLocalQueueAcknowledgment,
+	type LocalQueueAcknowledgment,
+} from './local-queue-acknowledgment.ts';
+import {
 	type AgentFinishContext,
 	type AgentFinishDeclaration,
 	type AgentOutputChannel,
@@ -1442,16 +1446,20 @@ export class Session implements FlueSession, AgentSubmissionSession {
 		// Steer the callbacks' appends now, grouped in declaration order —
 		// durable order equals steer order, deterministic regardless of how the
 		// concurrent callbacks interleaved.
+		const acknowledgments: LocalQueueAcknowledgment[] = [];
 		for (const outcome of outcomes) {
 			if (outcome.status !== 'fulfilled') continue;
-			for (const message of outcome.value) this.enqueueSignalAppend(message);
+			for (const { message, acknowledgment } of outcome.value) {
+				this.enqueueSignalAppend(message);
+				if (acknowledgment) acknowledgments.push(acknowledgment);
+			}
 		}
 		const parentId =
 			this.pendingSignalAppends.length > 0
 				? await this.conversationWriter.getConversationLeaf(this.conversationId)
 				: null;
 		const { records: signalRecords } = this.drainSignalAppendRecords(parentId);
-		await this.appendCanonical([
+		const records: ConversationRecord[] = [
 			...signalRecords,
 			...this.drainHookStateRecords(),
 			{
@@ -1461,7 +1469,16 @@ export class Session implements FlueSession, AgentSubmissionSession {
 				submissionId,
 				type: 'agent_start_run',
 			},
-		]);
+		];
+		if (acknowledgments.length === 0) {
+			await this.appendCanonical(records);
+		} else {
+			await this.conversationWriter.appendWithLocalAcknowledgments(
+				records,
+				acknowledgments,
+				this.canonicalAppendOptions(),
+			);
+		}
 	}
 
 	/**
@@ -1507,20 +1524,28 @@ export class Session implements FlueSession, AgentSubmissionSession {
 		index: number,
 		hook: AgentStartDeclaration,
 		signal: AbortSignal,
-	): Promise<AgentSignalAppend[]> {
+	): Promise<Array<{ message: AgentSignalAppend; acknowledgment?: LocalQueueAcknowledgment }>> {
 		let harness: ActionHarness | undefined;
 		let appendWindowOpen = true;
-		const appends: AgentSignalAppend[] = [];
+		const appends: Array<{
+			message: AgentSignalAppend;
+			acknowledgment?: LocalQueueAcknowledgment;
+		}> = [];
 		// `this` is shadowed inside the ctx getter below.
 		const session = this;
 		const ctx: AgentStartContext = {
-			append: (message) => {
+			append: (message, options) => {
 				if (!appendWindowOpen) {
 					throw new Error(
 						'[flue] append() was called after its useAgentStart callback settled. The append window is the callback itself — to send input at any other time, use the dispatcher from useDispatchMessage().',
 					);
 				}
-				appends.push(assertAppendMessage(message));
+				const parsed = assertAppendMessage(message);
+				const acknowledgment =
+					options?.acknowledge === undefined
+						? undefined
+						: assertLocalQueueAcknowledgment(options.acknowledge);
+				appends.push({ message: parsed, acknowledgment });
 			},
 			log: this.createHookLogger('useAgentStart', index),
 			signal,


### PR DESCRIPTION
Start hooks currently buffer signals before the stream commits. A consumer that deletes a queued note after `append()` returns can lose that note when another hook or the batch fails.

Add `append(message, { acknowledge: { table, key } })` to `AgentStartContext`. It validates and copies the row key while staging. The local SQLite store deletes that row in the transaction that stores the signals, state writes, and start marker. A failed deletion rolls back the batch. A committed producer-batch replay skips deletion, so a later row with the same key remains queued.

The optional store method makes support explicit. The memory and async SQL stores refuse acknowledgments. Calls without acknowledgments keep their existing path. Each key must select exactly one application row in the same SQLite database. No stored format, coordinator, submission policy, package version, or Runner consumer changes.

Validation:

- 27 maintained regressions pass through Node SQLite, the runtime, and a local fake model provider. They cover hook and batch failure, partial deletion rollback, staging and declaration order, key mutation, database reopen, lost commit response, key reuse, joined delivery, producer and submission checks, unsupported stores, and ordinary appends.
- `pnpm build` passes all 59 tasks. `pnpm check:types` passes all 109 tasks, including fresh dependency builds after the review fixes.
- Scoped Biome lint passes with five existing warnings in unchanged Session code. Formatting and `git diff --check` pass.
- `pnpm check` stops on existing Knip findings: 48 unused development dependencies, 29 unused exports, and two unused exported types. `pnpm test` stops on existing packages without test files, first `@flue/whatsapp`. The focused runtime suite passes.

The complete staff review in the implementing session is finished. The review fixed row-key parsing that could omit `constructor`, `prototype`, or `__proto__`, qualified SQL columns, and corrected type and style details. No findings remain. Cloudflare uses the same SQLite store; these regressions do not execute workerd. This repository has no current PR test workflow.

Related work: RUN-7643. PR #675 shares the writer and store methods. Later integration must keep its cleanup validation after the producer check and before the committed-batch lookup. Keep acknowledgment execution after that lookup, preserve its cleanup-versus-submission check, and retain `abandonedMessage` forwarding. PR #674 and the RUN-7644 diagnostics changes do not share these hunks.
