### PR TITLE
feat(runtime): expose safe failed recovery decisions (RUN-7644)

### DIFF
--- a/apps/docs/src/content/docs/reference/events.md
+++ b/apps/docs/src/content/docs/reference/events.md
@@ -117,6 +117,7 @@ The v3 vocabulary contains 27 event types:
 - Agent lifecycle — [`agent_start`, `agent_end`, `idle`](#agent_start-agent_end-idle)
 - Submission lifecycle — [`submission_queued`, `submission_running`](#submission_queued-submission_running), [`submission_settled`](#submission_settled)
 - Recovery — [`submission_recovery`](#submission_recovery)
+- Attempt changes — [`submission_attempt_changed`](#submission_attempt_changed)
 - Operations — [`operation_start`, `operation`](#operation_start-operation)
 - Model turns — [`turn_start`, `turn_request`, `turn`, `turn_messages`](#turn_start-turn_request-turn-turn_messages)
 - Messages and deltas — [`message_start`, `message_end`, `text_delta`, `thinking_start`, `thinking_delta`, `thinking_end`, `toolcall_delta`](#message-and-delta-events)
@@ -190,6 +191,30 @@ observe((event) => {
 ```
 
 The pattern converges across process restarts and Durable Object eviction: a fresh isolate's recovery re-emits `submission_running` for every interrupted submission (and `submission_queued` re-fires on admission replays) before those submissions settle, so the new observer's busy set rebuilds itself. The at-least-once emissions are absorbed by the set semantics.
+
+### `submission_attempt_changed`
+
+```ts
+{
+  type: 'submission_attempt_changed';
+  submissionId: string;
+  kind: 'dispatch' | 'direct';
+  operation: 'claim_submission' | 'replace_submission_attempt';
+  previous: { attemptId: string | null; attemptCount: number } | null;
+  current: { attemptId: string; attemptCount: number };
+  maxAttempts: number;
+  reason: 'queued_claim' | 'interrupted_transcript';
+  position: { lastStreamOffset: string | null; pendingToolCount: number | null };
+}
+```
+
+Cloudflare and Node emit this event immediately after a guarded claim or replacement returns a changed row, before starting its execution. A rejected stale change returns no row and emits no event. The event uses the coordinator's envelope and event sequence, with `agentName` and `instanceId`.
+
+`current`, `submissionId`, `kind`, and `maxAttempts` come from the returned row. `previous` contains the observed prior attempt. Its `attemptId` is null when the observed row has no attempt ID. A queued row can be claimed and requeued after it is listed. If its observed count is no longer one below the returned count, the entire `previous` snapshot is null. Counts are submission attempts, independent of HTTP retries inside a model request.
+
+`reason` is `queued_claim` for a claim and `interrupted_transcript` for a replacement. The latter names the existing inspection result; it does not identify why the process stopped. `position` comes from that inspection, without another query. Claims have no inspection, so both fields are null. The built-in recovery inspection supplies the stream offset but does not count unresolved tool calls; `pendingToolCount` stays null. Null means unknown, not zero.
+
+Delivery is live and does not block execution. Observer failures are contained. A process can stop after the store commits and before the event reaches an observer. There is no replay, outbox, or exactly-once guarantee. The event does not change recovery, execution, or settlement.
 
 ### `submission_recovery`
 
@@ -538,17 +563,18 @@ Log events are runtime events only: the model never sees them and they never app
 For one durable submission whose `prompt` operation contains a single tool-calling turn, events arrive in this order:
 
 1. `submission_queued` at admission
-2. `submission_running` when the attempt starts processing
-3. `operation_start`, `agent_start`
-4. `message_start` / `message_end` for the user message
-5. `turn_start`, `turn_request`
-6. `message_start` for the assistant message; `text_delta`, `thinking_*`, and `toolcall_delta` interleave while it streams
-7. `turn`, then `message_end` for the completed assistant message
-8. per tool call: `tool_start` when execution begins, then `message_start` / `message_end` for its tool-result message when it finishes
-9. the terminal `tool` events when the batch commits, then `turn_messages`
-10. further turns repeat from step 5 until a turn produces no tool calls
-11. `agent_end`, `operation`, `idle`
-12. `submission_settled` when the submission settles
+2. `submission_attempt_changed` when the claim returns its changed row
+3. `submission_running` when the attempt starts processing
+4. `operation_start`, `agent_start`
+5. `message_start` / `message_end` for the user message
+6. `turn_start`, `turn_request`
+7. `message_start` for the assistant message; `text_delta`, `thinking_*`, and `toolcall_delta` interleave while it streams
+8. `turn`, then `message_end` for the completed assistant message
+9. per tool call: `tool_start` when execution begins, then `message_start` / `message_end` for its tool-result message when it finishes
+10. the terminal `tool` events when the batch commits, then `turn_messages`
+11. further turns repeat from step 6 until a turn produces no tool calls
+12. `agent_end`, `operation`, `idle`
+13. `submission_settled` when the submission settles
 
 The sequence describes the uncontended path. A delivery that joins an already-busy conversation can interleave additional user `message_start` / `message_end` pairs at turn boundaries — such a joined delivery contributes its own `submission_queued` and `submission_settled` but no `submission_running`.
 

--- a/apps/docs/src/content/docs/reference/events.md
+++ b/apps/docs/src/content/docs/reference/events.md
@@ -112,11 +112,12 @@ Two content guarantees hold for every event surface:
 
 ## Event types
 
-The v3 vocabulary contains 27 event types:
+The v3 vocabulary contains 28 event types:
 
 - Agent lifecycle — [`agent_start`, `agent_end`, `idle`](#agent_start-agent_end-idle)
 - Submission lifecycle — [`submission_queued`, `submission_running`](#submission_queued-submission_running), [`submission_settled`](#submission_settled)
 - Recovery — [`submission_recovery`](#submission_recovery)
+- Recovery decisions — [`submission_recovery_decision`](#submission_recovery_decision)
 - Attempt changes — [`submission_attempt_changed`](#submission_attempt_changed)
 - Operations — [`operation_start`, `operation`](#operation_start-operation)
 - Model turns — [`turn_start`, `turn_request`, `turn`, `turn_messages`](#turn_start-turn_request-turn-turn_messages)
@@ -215,6 +216,47 @@ Cloudflare and Node emit this event immediately after a guarded claim or replace
 `reason` is `queued_claim` for a claim and `interrupted_transcript` for a replacement. The latter names the existing inspection result; it does not identify why the process stopped. `position` comes from that inspection, without another query. Claims have no inspection, so both fields are null. The built-in recovery inspection supplies the stream offset but does not count unresolved tool calls; `pendingToolCount` stays null. Null means unknown, not zero.
 
 Delivery is live and does not block execution. Observer failures are contained. A process can stop after the store commits and before the event reaches an observer. There is no replay, outbox, or exactly-once guarantee. The event does not change recovery, execution, or settlement.
+
+### `submission_recovery_decision`
+
+```ts
+{
+  type: 'submission_recovery_decision';
+  submissionId?: string;
+  kind: 'dispatch' | 'direct' | null;
+  attempt: { attemptId: string | null; attemptCount: number } | null;
+  maxAttempts: number | null;
+  operation: 'reconcile_submission' | 'reconcile_pass';
+  reason: 'retry_exhausted' | 'timeout' | 'reconcile_failed';
+  position: { lastStreamOffset: string | null; pendingToolCount: number | null };
+  error: {
+    name: string | null;
+    retryable: boolean | null;
+    overloaded: boolean | null;
+    remote: boolean | null;
+  } | null;
+}
+```
+
+The coordinator selects a budget or timeout failure, or catches an error during reconciliation.
+The existing coordinator emitter sends this event to `observe()` without a request context.
+
+- `retry_exhausted` and `timeout` are emitted immediately before terminal work. Their `error` is null because no original error causes that choice.
+- Completion takes precedence over abort, budget, and timeout. Abort takes precedence over budget and timeout. Budget takes precedence over timeout.
+- `reconcile_failed` reports an existing reconciliation catch, including a failed terminal-record write. It can follow an earlier budget or timeout decision.
+- The event records the selected action or caught failure. It does not confirm settlement. Read the existing settlement record for the terminal result.
+- Available submission and attempt fields come from the current reconciliation row. A pass without a row omits `submissionId` and sets `kind`, `attempt`, and `maxAttempts` to null.
+- Position comes from the existing inspection. Without that result, both fields are null. The current inspection does not count pending tools, so `pendingToolCount` stays null.
+
+The error summary examines at most four entries in the original cause chain.
+A failed property read supplies an unknown value. A repeated object stops the scan.
+It selects the first entry with a Boolean `retryable`, `overloaded`, or `remote` flag; otherwise it selects the first safely named entry.
+The name and flags always come from the same entry. Names must match `[A-Za-z_$][A-Za-z0-9_$.-]{0,79}` in full.
+Invalid or absent names and flags are null. With no usable entry, `error` is null.
+This event adds no message, stack, request, body, metadata object, or `errorInfo` detail.
+
+Delivery is live only. A process failure can lose an event, and later failed wakes can emit another event.
+Subscriber failures do not change execution. No query, retry, attempt, or stored record is added by this event.
 
 ### `submission_recovery`
 

--- a/packages/runtime/src/cloudflare/agent-coordinator.ts
+++ b/packages/runtime/src/cloudflare/agent-coordinator.ts
@@ -21,6 +21,7 @@ import {
 	createDirectAgentSubmissionInput,
 	createDispatchAgentSubmissionInput,
 	emitSubmissionAttemptChanged,
+	emitSubmissionRecoveryDecision,
 	ensureInstanceIdentity,
 	finalizePendingSettlement,
 	type InstanceContactAdmission,
@@ -760,6 +761,11 @@ class CloudflareAgentCoordinator {
 				}
 			}
 		} catch (error) {
+			emitSubmissionRecoveryDecision(this.emitCoordinatorEvent, {
+				operation: 'reconcile_pass',
+				reason: 'reconcile_failed',
+				error,
+			});
 			console.error(
 				'[flue:submission-reconciliation]',
 				{
@@ -826,6 +832,14 @@ class CloudflareAgentCoordinator {
 			| 'start_submission',
 		error: unknown,
 	): void {
+		if (operation === 'reconcile_submission') {
+			emitSubmissionRecoveryDecision(this.emitCoordinatorEvent, {
+				submission,
+				operation,
+				reason: 'reconcile_failed',
+				error,
+			});
+		}
 		console.error(
 			'[flue:submission-reconciliation]',
 			{

--- a/packages/runtime/src/cloudflare/agent-coordinator.ts
+++ b/packages/runtime/src/cloudflare/agent-coordinator.ts
@@ -20,6 +20,7 @@ import {
 	type createAgentSubmissionSessionHandler,
 	createDirectAgentSubmissionInput,
 	createDispatchAgentSubmissionInput,
+	emitSubmissionAttemptChanged,
 	ensureInstanceIdentity,
 	finalizePendingSettlement,
 	type InstanceContactAdmission,
@@ -748,7 +749,15 @@ class CloudflareAgentCoordinator {
 					ownerId: this.instance.ctx.id.toString(),
 					leaseExpiresAt: 0,
 				});
-				if (claimed) toStart.push(claimed);
+				if (claimed) {
+					emitSubmissionAttemptChanged(
+						submission,
+						claimed,
+						'claim_submission',
+						this.emitCoordinatorEvent,
+					);
+					toStart.push(claimed);
+				}
 			}
 		} catch (error) {
 			console.error(

--- a/packages/runtime/src/node/agent-coordinator.ts
+++ b/packages/runtime/src/node/agent-coordinator.ts
@@ -18,6 +18,7 @@ import {
 	createDirectAgentSubmissionInput,
 	createDispatchAgentSubmissionInput,
 	emitSubmissionAttemptChanged,
+	emitSubmissionRecoveryDecision,
 	ensureInstanceIdentity,
 	finalizePendingSettlement,
 	type InstanceContactAdmission,
@@ -471,6 +472,11 @@ export function createNodeAgentCoordinator(options: {
 					// schedule one more pass).
 				} while (!stopping && (progressed || wakeRequested));
 			} catch (error) {
+				emitSubmissionRecoveryDecision(passEventEmitter, {
+					operation: 'reconcile_pass',
+					reason: 'reconcile_failed',
+					error,
+				});
 				// A transient DB error in listRunnableSubmissions or
 				// claimSubmission should not kill the entire loop. Log,
 				// back off briefly, and retry. Setting wakeRequested ensures
@@ -523,6 +529,11 @@ export function createNodeAgentCoordinator(options: {
 		// Errors in individual submissions are caught by spawnSubmissionTask.
 		// Unexpected errors in the loop itself are fatal and logged.
 		claimLoopDone = claimLoop().catch((error) => {
+			emitSubmissionRecoveryDecision(passEventEmitter, {
+				operation: 'reconcile_pass',
+				reason: 'reconcile_failed',
+				error,
+			});
 			console.error('[flue:claim-loop] Fatal error in claim loop:', error);
 			passEventEmitter(
 				{
@@ -694,6 +705,12 @@ export function createNodeAgentCoordinator(options: {
 				activeSubmissions.delete(submissionId);
 				conversationWriters.delete(agentStreamPath(submission.input.agent, submission.input.id));
 			} catch (error) {
+				emitSubmissionRecoveryDecision(coordinatorEventEmitter(submission.input), {
+					submission,
+					operation: 'reconcile_submission',
+					reason: 'reconcile_failed',
+					error,
+				});
 				coordinatorEventEmitter(submission.input)(
 					{
 						type: 'submission_recovery',
@@ -930,6 +947,12 @@ export function createNodeAgentCoordinator(options: {
 					spawnSubmissionTask(replacement);
 				}
 			} catch (error) {
+				emitSubmissionRecoveryDecision(coordinatorEventEmitter(submission.input), {
+					submission,
+					operation: 'reconcile_submission',
+					reason: 'reconcile_failed',
+					error,
+				});
 				console.error(
 					'[flue:submission-reconciliation]',
 					{
@@ -1112,6 +1135,11 @@ export function createNodeAgentCoordinator(options: {
 			wake();
 			if (hasInactive) {
 				void reconcileRunningSubmissions().catch((error) => {
+					emitSubmissionRecoveryDecision(passEventEmitter, {
+						operation: 'reconcile_pass',
+						reason: 'reconcile_failed',
+						error,
+					});
 					console.error('[flue:submission-abort] reconcile after abort failed:', error);
 					passEventEmitter(
 						{

--- a/packages/runtime/src/node/agent-coordinator.ts
+++ b/packages/runtime/src/node/agent-coordinator.ts
@@ -17,6 +17,7 @@ import {
 	adoptKeyedSubmissionReplay,
 	createDirectAgentSubmissionInput,
 	createDispatchAgentSubmissionInput,
+	emitSubmissionAttemptChanged,
 	ensureInstanceIdentity,
 	finalizePendingSettlement,
 	type InstanceContactAdmission,
@@ -429,6 +430,12 @@ export function createNodeAgentCoordinator(options: {
 				leaseExpiresAt: Date.now() + LEASE_DURATION_MS,
 			});
 			if (!claimed) continue;
+			emitSubmissionAttemptChanged(
+				submission,
+				claimed,
+				'claim_submission',
+				coordinatorEventEmitter(claimed.input),
+			);
 			progressed = true;
 			spawnSubmissionTask(claimed);
 		}

--- a/packages/runtime/src/runtime/agent-submissions.ts
+++ b/packages/runtime/src/runtime/agent-submissions.ts
@@ -26,7 +26,7 @@ import {
 } from '../errors.ts';
 import { type FlueTraceCarrier, interceptExecution } from '../execution-interceptor.ts';
 import { getInternalSession } from '../session.ts';
-import type { Agent, CallHandle, DeliveredMessage } from '../types.ts';
+import type { Agent, CallHandle, DeliveredMessage, FlueEventInput } from '../types.ts';
 import { type AttachmentStore, createAttachmentRef } from './attachment-store.ts';
 import type { DispatchInput } from './dispatch-queue.ts';
 import type { CoordinatorEventEmitter } from './events.ts';
@@ -78,6 +78,13 @@ export interface InterruptedToolCallRef {
 
 export type AgentSubmissionInspection = 'absent' | 'completed' | 'interrupted';
 
+type SubmissionAttemptChanged = Extract<FlueEventInput, { type: 'submission_attempt_changed' }>;
+
+export interface AgentSubmissionInspectionSnapshot {
+	readonly state: AgentSubmissionInspection;
+	readonly position: SubmissionAttemptChanged['position'];
+}
+
 export interface ProcessAgentSubmissionOptions {
 	submissionAttempt?: SubmissionAttemptRef;
 	onInputApplied?: (durability: SubmissionDurability) => Promise<void> | void;
@@ -120,7 +127,7 @@ export interface AgentSubmissionSession {
 	readonly conversationId: string;
 	inspectSubmissionInput(
 		input: AgentSubmissionInput,
-	): Promise<AgentSubmissionInspection> | AgentSubmissionInspection;
+	): Promise<AgentSubmissionInspectionSnapshot> | AgentSubmissionInspectionSnapshot;
 	processSubmissionInput(
 		input: AgentSubmissionInput,
 		options?: ProcessAgentSubmissionOptions,
@@ -472,6 +479,38 @@ export function createAgentSubmissionSessionHandler(
 	};
 }
 
+/** Report only the attempt returned by a successful store change. */
+export function emitSubmissionAttemptChanged(
+	previous: AgentSubmission,
+	current: AgentSubmission,
+	operation: SubmissionAttemptChanged['operation'],
+	emit: CoordinatorEventEmitter | undefined,
+	position: SubmissionAttemptChanged['position'] = {
+		lastStreamOffset: null,
+		pendingToolCount: null,
+	},
+): void {
+	if (!current.attemptId) return;
+	// Claims guard queued status, but the row can be claimed and requeued
+	// after it was listed. Keep that stale prior snapshot unknown.
+	const previousApplies =
+		operation === 'replace_submission_attempt' ||
+		previous.attemptCount === current.attemptCount - 1;
+	emit?.({
+		type: 'submission_attempt_changed',
+		submissionId: current.submissionId,
+		kind: current.kind,
+		operation,
+		previous: previousApplies
+			? { attemptId: previous.attemptId ?? null, attemptCount: previous.attemptCount }
+			: null,
+		current: { attemptId: current.attemptId, attemptCount: current.attemptCount },
+		maxAttempts: current.maxAttempts,
+		reason: operation === 'claim_submission' ? 'queued_claim' : 'interrupted_transcript',
+		position,
+	});
+}
+
 /**
  * Shared reconciliation decision tree for an interrupted running submission.
  * Used by both the Cloudflare and Node agent coordinators.
@@ -505,9 +544,10 @@ export async function reconcileInterruptedSubmission(
 	// requeue branches — exhausting either must never discard (or append a
 	// contradictory interruption advisory over) work that already completed.
 	const ctx = createContext(input.submissionId);
-	const state = (await createAgentSubmissionSessionHandler(agent, input, (s) =>
+	const inspection = (await createAgentSubmissionSessionHandler(agent, input, (s) =>
 		s.inspectSubmissionInput(input),
-	)(ctx)) as AgentSubmissionInspection;
+	)(ctx)) as AgentSubmissionInspectionSnapshot;
+	const { state } = inspection;
 	if (state === 'completed') {
 		await settleJoinedSubmissions(
 			submissions,
@@ -658,6 +698,13 @@ export async function reconcileInterruptedSubmission(
 			lease,
 		);
 		if (!replacement?.attemptId) return undefined;
+		emitSubmissionAttemptChanged(
+			submission,
+			replacement,
+			'replace_submission_attempt',
+			emitCoordinatorEvent,
+			inspection.position,
+		);
 		return replacement;
 	}
 

--- a/packages/runtime/src/runtime/agent-submissions.ts
+++ b/packages/runtime/src/runtime/agent-submissions.ts
@@ -511,6 +511,89 @@ export function emitSubmissionAttemptChanged(
 	});
 }
 
+type SubmissionRecoveryDecision = Extract<FlueEventInput, { type: 'submission_recovery_decision' }>;
+
+function recoveryErrorField(error: object, key: string): unknown {
+	try {
+		return Reflect.get(error, key);
+	} catch {
+		return undefined;
+	}
+}
+
+function recoveryErrorSummary(error: unknown): SubmissionRecoveryDecision['error'] {
+	const seen = new Set<object>();
+	let named: SubmissionRecoveryDecision['error'] = null;
+	let current = error;
+	for (let depth = 0; depth < 4; depth++) {
+		if (
+			current === null ||
+			(typeof current !== 'object' && typeof current !== 'function') ||
+			seen.has(current)
+		)
+			break;
+		seen.add(current);
+		const rawName = recoveryErrorField(current, 'name');
+		// Match the whole name; "$" alone also accepts a final line break.
+		const name =
+			typeof rawName === 'string' &&
+			rawName.match(/^[A-Za-z_$][A-Za-z0-9_$.-]{0,79}$/)?.[0] === rawName
+				? rawName
+				: null;
+		const retryable = recoveryErrorField(current, 'retryable');
+		const overloaded = recoveryErrorField(current, 'overloaded');
+		const remote = recoveryErrorField(current, 'remote');
+		const summary = {
+			name,
+			retryable: typeof retryable === 'boolean' ? retryable : null,
+			overloaded: typeof overloaded === 'boolean' ? overloaded : null,
+			remote: typeof remote === 'boolean' ? remote : null,
+		};
+		// Keep the platform flags and name from the same cause entry.
+		if (summary.retryable !== null || summary.overloaded !== null || summary.remote !== null) {
+			return summary;
+		}
+		if (name !== null && named === null) named = summary;
+		current = recoveryErrorField(current, 'cause');
+	}
+	return named;
+}
+
+/** Report a recovery decision without changing recovery when reporting fails. */
+export function emitSubmissionRecoveryDecision(
+	emit: CoordinatorEventEmitter | undefined,
+	options: {
+		readonly submission?: AgentSubmission;
+		readonly operation: SubmissionRecoveryDecision['operation'];
+		readonly reason: SubmissionRecoveryDecision['reason'];
+		readonly position?: SubmissionRecoveryDecision['position'];
+		readonly error?: unknown;
+	},
+): void {
+	if (!emit) return;
+	try {
+		const { submission, position } = options;
+		emit({
+			type: 'submission_recovery_decision',
+			...(submission ? { submissionId: submission.submissionId } : {}),
+			kind: submission?.kind ?? null,
+			attempt: submission
+				? { attemptId: submission.attemptId ?? null, attemptCount: submission.attemptCount }
+				: null,
+			maxAttempts: submission?.maxAttempts ?? null,
+			operation: options.operation,
+			reason: options.reason,
+			position: {
+				lastStreamOffset: position?.lastStreamOffset ?? null,
+				pendingToolCount: position?.pendingToolCount ?? null,
+			},
+			error: options.reason === 'reconcile_failed' ? recoveryErrorSummary(options.error) : null,
+		});
+	} catch {
+		// Reporting must not replace the original failure or stop settlement.
+	}
+}
+
 /**
  * Shared reconciliation decision tree for an interrupted running submission.
  * Used by both the Cloudflare and Node agent coordinators.
@@ -597,6 +680,12 @@ export async function reconcileInterruptedSubmission(
 	// misdescribe work that never happened. The shared budget itself is
 	// intentional — only the message distinguishes the case.
 	if (submission.attemptCount >= submission.maxAttempts) {
+		emitSubmissionRecoveryDecision(emitCoordinatorEvent, {
+			submission,
+			operation: 'reconcile_submission',
+			reason: 'retry_exhausted',
+			position: inspection.position,
+		});
 		await failInterruptedSubmission(
 			submissions,
 			submission,
@@ -618,12 +707,19 @@ export async function reconcileInterruptedSubmission(
 			createContext,
 			conversationWriter,
 			emitCoordinatorEvent,
+			inspection.position,
 		);
 		return undefined;
 	}
 
 	// Check timeout.
 	if (submission.timeoutAt > 0 && Date.now() >= submission.timeoutAt) {
+		emitSubmissionRecoveryDecision(emitCoordinatorEvent, {
+			submission,
+			operation: 'reconcile_submission',
+			reason: 'timeout',
+			position: inspection.position,
+		});
 		await failInterruptedSubmission(
 			submissions,
 			submission,
@@ -634,6 +730,7 @@ export async function reconcileInterruptedSubmission(
 			createContext,
 			conversationWriter,
 			emitCoordinatorEvent,
+			inspection.position,
 		);
 		return undefined;
 	}
@@ -1042,6 +1139,7 @@ async function failInterruptedSubmission(
 	createContext: (submissionId: string) => FlueContextInternal,
 	conversationWriter?: ConversationRecordWriter,
 	emitCoordinatorEvent?: CoordinatorEventEmitter,
+	position?: SubmissionRecoveryDecision['position'],
 ): Promise<void> {
 	const { input } = submission;
 	const ctx = createContext(input.submissionId);
@@ -1063,6 +1161,13 @@ async function failInterruptedSubmission(
 			}),
 		)(ctx)) as ReadonlyArray<InterruptedToolCallRef>;
 	} catch (terminalError) {
+		emitSubmissionRecoveryDecision(emitCoordinatorEvent, {
+			submission,
+			operation: 'reconcile_submission',
+			reason: 'reconcile_failed',
+			position,
+			error: terminalError,
+		});
 		console.error(
 			'[flue:submission-reconciliation] Failed to record terminal message for submission',
 			submission.submissionId,

--- a/packages/runtime/src/runtime/submission-attempt-events.test.ts
+++ b/packages/runtime/src/runtime/submission-attempt-events.test.ts
@@ -1,0 +1,352 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createCallHandle } from '../abort.ts';
+import type { AgentSubmission } from '../agent-execution-store.ts';
+import { createFlueContext } from '../client.ts';
+import { createCloudflareAgentRuntime } from '../cloudflare/agent-coordinator.ts';
+import type { Harness } from '../harness.ts';
+import { observe } from '../index.ts';
+import { createNodeAgentCoordinator } from '../node/agent-coordinator.ts';
+import { sqlite } from '../node/agent-execution-store.ts';
+import type { FlueObservation } from '../types.ts';
+import type { AgentSubmissionInput, AgentSubmissionSession } from './agent-submissions.ts';
+import { drainGlobalEventDeliveries } from './events.ts';
+import { generateAttemptId, generateSubmissionId } from './ids.ts';
+
+type Platform = 'cloudflare' | 'node';
+type AttemptEvent = Extract<FlueObservation, { type: 'submission_attempt_changed' }>;
+const cleanups: Array<() => void | Promise<void>> = [];
+
+afterEach(async () => {
+	while (cleanups.length) await cleanups.pop()?.();
+	await drainGlobalEventDeliveries();
+	vi.restoreAllMocks();
+});
+
+async function setup(platform: Platform, kind: 'direct' | 'dispatch' = 'direct') {
+	const persistence = sqlite();
+	await persistence.migrate?.();
+	const stores = await persistence.connect();
+	cleanups.push(() => persistence.close?.());
+	const store = stores.submissionStore;
+	const input: AgentSubmissionInput = {
+		kind,
+		submissionId: generateSubmissionId(),
+		agent: 'AttemptAgent',
+		id: 'attempt-events',
+		message: { kind: 'user', body: 'Test input' },
+		acceptedAt: new Date().toISOString(),
+	};
+	if (kind === 'direct') await store.admitDirect(input);
+	else await store.admitDispatch(input);
+	await store.markSubmissionCanonicalReady(input.submissionId);
+	const order: string[] = [];
+	const changes: AttemptEvent[] = [];
+	const scopes: Array<{ id: string; req: Request | undefined }> = [];
+	cleanups.push(
+		observe((event, ctx) => {
+			if (event.type !== 'submission_attempt_changed') return;
+			order.push('event');
+			changes.push(event);
+			scopes.push({ id: ctx.id, req: ctx.req });
+		}),
+	);
+	const returned: AgentSubmission[] = [];
+	const getSubmission = store.getSubmission.bind(store);
+	vi.spyOn(store, 'getSubmission').mockImplementation((...args) => {
+		order.push('submission_read');
+		return getSubmission(...args);
+	});
+	const claim = store.claimSubmission.bind(store);
+	const replace = store.replaceSubmissionAttempt.bind(store);
+	vi.spyOn(store, 'claimSubmission').mockImplementation(async (...args) => {
+		const row = await claim(...args);
+		if (row) {
+			returned.push(row);
+			order.push('claim_return');
+		}
+		return row;
+	});
+	vi.spyOn(store, 'replaceSubmissionAttempt').mockImplementation(async (...args) => {
+		const row = await replace(...args);
+		if (row) {
+			returned.push(row);
+			order.push('replace_return');
+		}
+		return row;
+	});
+	// Keep the coordinators, SQL guards, and observe() real. The session
+	// driver completes locally, without a model or a provider request.
+	const session: AgentSubmissionSession = {
+		conversationId: 'test-conversation',
+		inspectSubmissionInput: vi.fn(() => ({
+			state: 'interrupted' as const,
+			position: { lastStreamOffset: '41', pendingToolCount: null },
+		})),
+		processSubmissionInput: () =>
+			createCallHandle(undefined, async () => {
+				order.push('process');
+			}),
+		recordSubmissionTerminal: async () => [],
+	};
+	const createContext = () => {
+		order.push('context');
+		const ctx = createFlueContext({
+			id: input.id,
+			agentName: input.agent,
+			submissionId: input.submissionId,
+			env: {},
+			agentConfig: { resolveModel: () => undefined },
+		});
+		ctx.initializeRootHarness = async () =>
+			({ session: async () => session }) as unknown as Harness;
+		return ctx;
+	};
+	const agents = [{ name: input.agent, agent: () => 'Test agent' }];
+	let wake: () => Promise<void>;
+	let idle: () => Promise<void>;
+	if (platform === 'cloudflare') {
+		const fibers: Promise<void>[] = [];
+		const deliveries: Promise<unknown>[] = [];
+		const runtime = createCloudflareAgentRuntime({
+			agents,
+			createContext,
+			runWithInstanceContext: (_instance, _agentName, callback) => callback(),
+		});
+		const instance = {
+			name: input.id,
+			env: {},
+			ctx: {
+				id: { toString: () => 'test-object' },
+				storage: {},
+				waitUntil: (promise: Promise<unknown>) => deliveries.push(promise),
+			},
+			schedule: async () => undefined,
+			runFiber: (
+				_name: string,
+				callback: (ctx: { stash(snapshot: unknown): void }) => Promise<void>,
+			) => {
+				order.push('fiber');
+				const fiber = callback({ stash: () => {} });
+				fibers.push(fiber);
+				return fiber;
+			},
+		};
+		runtime.attach(instance, { agentName: input.agent, ...stores });
+		wake = () => runtime.drainSubmissions(instance);
+		idle = async () => {
+			await Promise.all(fibers);
+			await Promise.all(deliveries);
+		};
+		cleanups.push(idle);
+	} else {
+		const coordinator = createNodeAgentCoordinator({
+			submissions: store,
+			agents,
+			createContext,
+		});
+		wake = () => coordinator.reconcileSubmissions();
+		idle = () => coordinator.waitForIdle();
+		cleanups.push(() => coordinator.shutdown());
+	}
+	const startInterrupted = async () => {
+		const row = await claim({
+			submissionId: input.submissionId,
+			attemptId: generateAttemptId(),
+			ownerId: 'previous-process',
+			leaseExpiresAt: Date.now() - 60_000,
+		});
+		expect(row?.attemptId).toBeDefined();
+		if (!row?.attemptId) throw new Error('Test claim did not return an attempt');
+		return { ...row, attemptId: row.attemptId };
+	};
+	return {
+		store,
+		input,
+		order,
+		changes,
+		scopes,
+		returned,
+		session,
+		claim,
+		replace,
+		wake,
+		idle,
+		startInterrupted,
+	};
+}
+
+describe.each<Platform>(['cloudflare', 'node'])('%s committed attempt events', (platform) => {
+	it.each(['direct', 'dispatch'] as const)(
+		'reports a returned %s claim before execution',
+		async (kind) => {
+			const test = await setup(platform, kind);
+			await Promise.all([test.wake(), test.wake()]);
+			await test.idle();
+			expect(test.changes).toHaveLength(1);
+			expect(test.scopes).toEqual([{ id: test.input.id, req: undefined }]);
+			const row = test.returned[0];
+			expect(row).toBeDefined();
+			expect(test.changes[0]).toEqual({
+				type: 'submission_attempt_changed',
+				submissionId: row?.submissionId,
+				kind,
+				operation: 'claim_submission',
+				previous: { attemptId: null, attemptCount: 0 },
+				current: { attemptId: row?.attemptId, attemptCount: row?.attemptCount },
+				maxAttempts: row?.maxAttempts,
+				reason: 'queued_claim',
+				position: { lastStreamOffset: null, pendingToolCount: null },
+				v: 3,
+				eventIndex: expect.any(Number),
+				timestamp: expect.any(String),
+				agentName: test.input.agent,
+				instanceId: test.input.id,
+			});
+			expect(test.order.slice(0, 3)).toEqual([
+				'claim_return',
+				'event',
+				platform === 'cloudflare' ? 'fiber' : 'submission_read',
+			]);
+			expect(test.order).toContain('process');
+			expect((await test.store.getSubmission(test.input.submissionId))?.status).toBe('settled');
+		},
+	);
+
+	it('keeps the observed count after requeue without inventing a prior ID', async () => {
+		const test = await setup(platform);
+		for (let count = 0; count < 3; count++) {
+			const old = await test.startInterrupted();
+			await test.store.markSubmissionInputApplied(old, {
+				maxAttempts: 7,
+				timeoutAt: Date.now() + 60_000,
+			});
+			await test.store.requeueSubmission(old);
+		}
+		await test.wake();
+		await test.idle();
+		expect(test.changes).toHaveLength(1);
+		expect(test.changes[0]?.previous).toEqual({ attemptId: null, attemptCount: 3 });
+		expect(test.changes[0]?.current.attemptCount).toBe(4);
+		expect(test.changes[0]?.maxAttempts).toBe(10);
+	});
+
+	it('leaves a stale queued snapshot unknown after a competing claim and requeue', async () => {
+		const test = await setup(platform);
+		const list = test.store.listRunnableSubmissions.bind(test.store);
+		vi.spyOn(test.store, 'listRunnableSubmissions').mockImplementationOnce(async () => {
+			const selected = await list();
+			await test.store.requeueSubmission(await test.startInterrupted());
+			return selected;
+		});
+		await test.wake();
+		await test.idle();
+		expect(test.changes).toHaveLength(1);
+		expect(test.changes[0]?.previous).toBeNull();
+		expect(test.changes[0]?.current).toEqual({
+			attemptId: test.returned[0]?.attemptId,
+			attemptCount: 2,
+		});
+	});
+
+	it('emits no change when a competing claim makes the selected row stale', async () => {
+		const test = await setup(platform);
+		const list = test.store.listRunnableSubmissions.bind(test.store);
+		vi.spyOn(test.store, 'listRunnableSubmissions').mockImplementationOnce(async () => {
+			const selected = await list();
+			await test.claim({
+				submissionId: test.input.submissionId,
+				attemptId: generateAttemptId(),
+				ownerId: 'competing-process',
+				leaseExpiresAt: Date.now() + 60_000,
+			});
+			return selected;
+		});
+		await test.wake();
+		await test.idle();
+		expect(test.store.claimSubmission).toHaveBeenCalled();
+		expect(test.returned).toEqual([]);
+		expect(test.changes).toEqual([]);
+		expect(test.order).not.toContain('process');
+	});
+
+	it('reports the guarded replacement once with its current and previous IDs', async () => {
+		const test = await setup(platform);
+		const old = await test.startInterrupted();
+		await Promise.all([test.wake(), test.wake()]);
+		await test.idle();
+		expect(test.changes).toHaveLength(1);
+		const row = test.returned[0];
+		expect(row?.attemptId).not.toBe(old.attemptId);
+		expect(test.changes[0]).toMatchObject({
+			submissionId: old.submissionId,
+			operation: 'replace_submission_attempt',
+			previous: { attemptId: old.attemptId, attemptCount: old.attemptCount },
+			current: { attemptId: row?.attemptId, attemptCount: row?.attemptCount },
+			maxAttempts: row?.maxAttempts,
+			reason: 'interrupted_transcript',
+			position: { lastStreamOffset: '41', pendingToolCount: null },
+		});
+		const committed = test.order.indexOf('replace_return');
+		expect(committed).toBeGreaterThanOrEqual(0);
+		expect(test.order.slice(committed, committed + 3)).toEqual([
+			'replace_return',
+			'event',
+			platform === 'cloudflare' ? 'fiber' : 'submission_read',
+		]);
+		expect(test.order.filter((step) => step === 'process')).toHaveLength(1);
+	});
+
+	it('emits no change for a replacement rejected by the attempt guard', async () => {
+		const test = await setup(platform);
+		await test.startInterrupted();
+		const method = platform === 'cloudflare' ? 'listRunningSubmissions' : 'listExpiredSubmissions';
+		const list = test.store[method].bind(test.store);
+		vi.spyOn(test.store, method).mockImplementationOnce(async () => {
+			const selected = await list();
+			const old = selected[0];
+			if (!old?.attemptId) throw new Error('Test recovery found no running attempt');
+			await test.replace(
+				{ submissionId: old.submissionId, attemptId: old.attemptId },
+				generateAttemptId(),
+				{
+					ownerId: 'competing-process',
+					leaseExpiresAt: Date.now() + 60_000,
+				},
+			);
+			return selected;
+		});
+		await test.wake();
+		await test.idle();
+		expect(test.store.replaceSubmissionAttempt).toHaveBeenCalled();
+		expect(test.returned).toEqual([]);
+		expect(test.changes).toEqual([]);
+		expect(test.order).not.toContain('process');
+	});
+
+	it.each(['claim', 'replacement'])(
+		'contains thrown and rejected observers during a %s',
+		async (operation) => {
+			const failure = new Error('Test observer failure');
+			const logged = vi.spyOn(console, 'error').mockImplementation(() => {});
+			cleanups.push(
+				observe((event) => {
+					if (event.type === 'submission_attempt_changed') throw failure;
+				}),
+			);
+			cleanups.push(
+				observe(async (event) => {
+					if (event.type === 'submission_attempt_changed') throw failure;
+				}),
+			);
+			const test = await setup(platform);
+			if (operation === 'replacement') await test.startInterrupted();
+			await test.wake();
+			await test.idle();
+			await drainGlobalEventDeliveries();
+			expect(test.changes).toHaveLength(1);
+			expect(test.order).toContain('process');
+			expect((await test.store.getSubmission(test.input.submissionId))?.status).toBe('settled');
+			expect(logged.mock.calls.filter(([, error]) => error === failure)).toHaveLength(2);
+		},
+	);
+});

--- a/packages/runtime/src/runtime/submission-recovery-events.test.ts
+++ b/packages/runtime/src/runtime/submission-recovery-events.test.ts
@@ -1,0 +1,537 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { createCallHandle } from '../abort.ts';
+import type { AgentSubmission, AgentSubmissionStore } from '../agent-execution-store.ts';
+import { createFlueContext } from '../client.ts';
+import { createCloudflareAgentRuntime } from '../cloudflare/agent-coordinator.ts';
+import type { Harness } from '../harness.ts';
+import { observe } from '../index.ts';
+import { createNodeAgentCoordinator } from '../node/agent-coordinator.ts';
+import { sqlite } from '../node/agent-execution-store.ts';
+import type { FlueObservation } from '../types.ts';
+import {
+	type AgentSubmissionInput,
+	type AgentSubmissionInspection,
+	type AgentSubmissionSession,
+	emitSubmissionRecoveryDecision,
+} from './agent-submissions.ts';
+import { createCoordinatorEventEmitter, drainGlobalEventDeliveries } from './events.ts';
+import { generateAttemptId, generateSubmissionId } from './ids.ts';
+
+type Platform = 'cloudflare' | 'node';
+type Decision = Extract<FlueObservation, { type: 'submission_recovery_decision' }>;
+const cleanups: Array<() => void | Promise<void>> = [];
+const position = { lastStreamOffset: '41', pendingToolCount: null };
+
+afterEach(async () => {
+	while (cleanups.length) await cleanups.pop()?.();
+	await drainGlobalEventDeliveries();
+});
+
+async function setup(
+	platform: Platform,
+	options: {
+		state?: AgentSubmissionInspection;
+		kind?: 'direct' | 'dispatch';
+		count?: number;
+		timedOut?: boolean;
+		aborted?: boolean;
+		inspect?: () => void | Promise<void>;
+		terminal?: () => void | Promise<void>;
+		beforeStoreCall?: (method: PropertyKey) => void;
+		afterRunningList?: (rows: AgentSubmission[]) => Promise<void>;
+	} = {},
+) {
+	const persistence = sqlite();
+	await persistence.migrate?.();
+	const stores = await persistence.connect();
+	cleanups.push(() => persistence.close?.());
+	const sqlStore = stores.submissionStore;
+	const input: AgentSubmissionInput = {
+		kind: options.kind ?? 'direct',
+		submissionId: generateSubmissionId(),
+		agent: 'RecoveryAgent',
+		id: 'recovery-events',
+		message: { kind: 'user', body: 'Local test input' },
+		acceptedAt: new Date().toISOString(),
+	};
+	if (input.kind === 'direct') await sqlStore.admitDirect(input);
+	else await sqlStore.admitDispatch(input);
+	await sqlStore.markSubmissionCanonicalReady(input.submissionId);
+	let claimed = await sqlStore.claimSubmission({
+		submissionId: input.submissionId,
+		attemptId: generateAttemptId(),
+		ownerId: 'old-process',
+		leaseExpiresAt: Date.now() - 60_000,
+	});
+	for (let count = 1; count < (options.count ?? 10); count++) {
+		if (!claimed?.attemptId) throw new Error('Missing test attempt');
+		await sqlStore.requeueSubmission({
+			submissionId: input.submissionId,
+			attemptId: claimed.attemptId,
+		});
+		claimed = await sqlStore.claimSubmission({
+			submissionId: input.submissionId,
+			attemptId: generateAttemptId(),
+			ownerId: 'old-process',
+			leaseExpiresAt: Date.now() - 60_000,
+		});
+	}
+	if (!claimed?.attemptId) throw new Error('Missing test claim');
+	const attempt = { submissionId: input.submissionId, attemptId: claimed.attemptId };
+	if (options.timedOut) {
+		await sqlStore.markSubmissionInputApplied(attempt, {
+			maxAttempts: 10,
+			timeoutAt: Date.now() - 1,
+		});
+	}
+	if (options.aborted) await sqlStore.requestSessionAbort(claimed.sessionKey);
+	const row = await sqlStore.getSubmission(input.submissionId);
+	if (!row) throw new Error('Missing test row');
+
+	// Inject a recording adapter. All normal operations still use the real SQL store.
+	const calls: string[] = [];
+	const store: AgentSubmissionStore = new Proxy(sqlStore, {
+		get(target, key) {
+			const value = Reflect.get(target, key);
+			if (typeof value !== 'function') return value;
+			return async (...args: unknown[]) => {
+				calls.push(String(key));
+				options.beforeStoreCall?.(key);
+				if (key === 'listRunningSubmissions' || key === 'listExpiredSubmissions') {
+					const result = await target[key]();
+					await options.afterRunningList?.(result);
+					return result;
+				}
+				return Reflect.apply(value, target, args);
+			};
+		},
+	});
+	const order: string[] = [];
+	const events: FlueObservation[] = [];
+	const unsubscribe = observe((event) => {
+		events.push(event);
+		if (event.type === 'submission_recovery_decision') order.push(event.reason);
+	});
+	cleanups.push(unsubscribe);
+	const session: AgentSubmissionSession = {
+		conversationId: 'test-conversation',
+		inspectSubmissionInput: async () => {
+			order.push('inspect');
+			await options.inspect?.();
+			return { state: options.state ?? 'interrupted', position };
+		},
+		processSubmissionInput: () =>
+			createCallHandle(undefined, async () => {
+				order.push('process');
+			}),
+		recordSubmissionTerminal: async () => {
+			order.push('terminal');
+			await options.terminal?.();
+			return [];
+		},
+	};
+	const createContext = () => {
+		order.push('context');
+		const ctx = createFlueContext({
+			id: input.id,
+			agentName: input.agent,
+			submissionId: input.submissionId,
+			env: {},
+			agentConfig: { resolveModel: () => undefined },
+		});
+		// SAFETY: openAgentSubmissionSession explicitly supports this local driver.
+		ctx.initializeRootHarness = async () =>
+			({ session: async () => session }) as unknown as Harness;
+		return ctx;
+	};
+	const agents = [{ name: input.agent, agent: () => 'Local recovery test' }];
+	let wake: () => Promise<void>;
+	let idle: () => Promise<void>;
+	if (platform === 'cloudflare') {
+		const fibers: Promise<unknown>[] = [];
+		const runtime = createCloudflareAgentRuntime({
+			agents,
+			createContext,
+			runWithInstanceContext: (_instance, _name, callback) => callback(),
+		});
+		const instance = {
+			name: input.id,
+			env: {},
+			ctx: {
+				id: { toString: () => 'test-object' },
+				storage: {},
+				waitUntil: (p: Promise<unknown>) => fibers.push(p),
+			},
+			schedule: async () => undefined,
+			runFiber: (
+				_name: string,
+				callback: (ctx: { stash(snapshot: unknown): void }) => Promise<void>,
+			) => {
+				const fiber = callback({ stash: () => {} });
+				fibers.push(fiber);
+				return fiber;
+			},
+		};
+		runtime.attach(instance, { agentName: input.agent, ...stores, submissionStore: store });
+		wake = () => runtime.drainSubmissions(instance);
+		idle = async () => {
+			await Promise.all(fibers);
+		};
+		cleanups.push(idle);
+	} else {
+		const coordinator = createNodeAgentCoordinator({ submissions: store, agents, createContext });
+		wake = () => coordinator.reconcileSubmissions();
+		idle = () => coordinator.waitForIdle();
+		cleanups.push(() => coordinator.shutdown());
+	}
+	return {
+		wake,
+		idle,
+		sqlStore,
+		input,
+		row,
+		order,
+		events,
+		calls,
+		decisions: () =>
+			events.filter((event): event is Decision => event.type === 'submission_recovery_decision'),
+	};
+}
+
+describe.each<Platform>(['cloudflare', 'node'])('%s recovery decisions', (platform) => {
+	it.each(['absent', 'interrupted'] as const)(
+		'reports %s at the limit before terminal work',
+		async (state) => {
+			const test = await setup(platform, { state });
+			await test.wake();
+			await test.idle();
+			expect(test.decisions()).toHaveLength(1);
+			expect(test.decisions()[0]).toEqual({
+				type: 'submission_recovery_decision',
+				submissionId: test.input.submissionId,
+				kind: 'direct',
+				attempt: { attemptId: test.row.attemptId, attemptCount: 10 },
+				maxAttempts: 10,
+				operation: 'reconcile_submission',
+				reason: 'retry_exhausted',
+				position,
+				error: null,
+				v: 3,
+				eventIndex: expect.any(Number),
+				timestamp: expect.any(String),
+				agentName: test.input.agent,
+				instanceId: test.input.id,
+			});
+			expect(test.order).toEqual(['context', 'inspect', 'retry_exhausted', 'context', 'terminal']);
+			const settled = await test.sqlStore.getSubmission(test.input.submissionId);
+			expect(settled?.status).toBe('settled');
+			expect(settled?.attemptCount).toBe(10);
+			expect(settled?.error).toContain(state === 'absent' ? 'before input' : 'recovery attempts');
+		},
+	);
+
+	it('keeps completed-at-limit ahead of abort, budget, and timeout', async () => {
+		const test = await setup(platform, { state: 'completed', aborted: true, timedOut: true });
+		await test.wake();
+		await test.idle();
+		expect(test.decisions()).toEqual([]);
+		expect(test.order).toEqual(['context', 'inspect']);
+		expect(test.events).toContainEqual(
+			expect.objectContaining({ type: 'submission_settled', outcome: 'completed' }),
+		);
+		expect((await test.sqlStore.getSubmission(test.input.submissionId))?.error).toBeUndefined();
+	});
+
+	it('keeps abort ahead of budget and timeout', async () => {
+		const test = await setup(platform, { aborted: true, timedOut: true });
+		await test.wake();
+		await test.idle();
+		expect(test.decisions()).toEqual([]);
+		expect(test.events).toContainEqual(
+			expect.objectContaining({ type: 'submission_settled', outcome: 'aborted' }),
+		);
+	});
+
+	it.each([1, 10])('selects the existing budget/timeout order at count %s', async (count) => {
+		const test = await setup(platform, { kind: 'dispatch', count, timedOut: true });
+		await test.wake();
+		await test.idle();
+		expect(test.decisions()).toHaveLength(1);
+		expect(test.decisions()[0]).toMatchObject({
+			kind: 'dispatch',
+			reason: count === 10 ? 'retry_exhausted' : 'timeout',
+			error: null,
+		});
+		expect(test.order.slice(2)).toEqual([
+			count === 10 ? 'retry_exhausted' : 'timeout',
+			'context',
+			'terminal',
+		]);
+	});
+
+	it('reports the caught terminal write separately and still settles', async () => {
+		const test = await setup(platform, {
+			terminal: () => {
+				throw new Error('Local terminal failure');
+			},
+		});
+		await test.wake();
+		await test.idle();
+		expect(test.decisions().map((event) => event.reason)).toEqual([
+			'retry_exhausted',
+			'reconcile_failed',
+		]);
+		expect(test.decisions()[1]).toMatchObject({
+			position,
+			error: { name: 'Error', retryable: null, overloaded: null, remote: null },
+		});
+		expect(test.order.slice(2)).toEqual([
+			'retry_exhausted',
+			'context',
+			'terminal',
+			'reconcile_failed',
+		]);
+		expect(test.events).toContainEqual(
+			expect.objectContaining({ type: 'submission_recovery', outcome: 'terminated' }),
+		);
+		expect((await test.sqlStore.getSubmission(test.input.submissionId))?.status).toBe('settled');
+	});
+
+	it('leaves the position unknown when inspection fails', async () => {
+		const error = Object.assign(new Error('Local inspection failure'), {
+			retryable: false,
+			remote: true,
+		});
+		const test = await setup(platform, {
+			inspect: () => {
+				throw error;
+			},
+		});
+		await test.wake();
+		await test.idle();
+		expect(test.decisions()).toHaveLength(1);
+		expect(test.decisions()[0]).toMatchObject({
+			submissionId: test.input.submissionId,
+			attempt: { attemptId: test.row.attemptId, attemptCount: 10 },
+			reason: 'reconcile_failed',
+			position: { lastStreamOffset: null, pendingToolCount: null },
+			error: { name: 'Error', retryable: false, overloaded: null, remote: true },
+		});
+		expect(
+			test.events.findIndex((event) => event.type === 'submission_recovery_decision'),
+		).toBeLessThan(test.events.findIndex((event) => event.type === 'submission_recovery'));
+		expect((await test.sqlStore.getSubmission(test.input.submissionId))?.status).toBe('running');
+	});
+
+	it('keeps a selected failure distinct from failed settlement', async () => {
+		const test = await setup(platform, {
+			beforeStoreCall: (method) => {
+				if (method === 'failSubmission') throw new Error('Local settlement failure');
+			},
+		});
+		await test.wake();
+		await test.idle();
+		expect(test.decisions().map((event) => event.reason)).toEqual([
+			'retry_exhausted',
+			'reconcile_failed',
+		]);
+		expect(test.events.some((event) => event.type === 'submission_settled')).toBe(false);
+		expect((await test.sqlStore.getSubmission(test.input.submissionId))?.status).toBe('running');
+	});
+
+	it('omits submission fields for a pass failure without a row', async () => {
+		let failures = 0;
+		const test = await setup(platform, {
+			beforeStoreCall: (method) => {
+				if (method === 'listRunnableSubmissions' && failures++ === 0)
+					throw new Error('Local list failure');
+			},
+		});
+		await test.wake();
+		await test.idle();
+		const pass = test.decisions().filter((event) => event.operation === 'reconcile_pass');
+		expect(pass).toHaveLength(1);
+		expect(pass[0]).toMatchObject({
+			reason: 'reconcile_failed',
+			kind: null,
+			attempt: null,
+			maxAttempts: null,
+			position: { lastStreamOffset: null, pendingToolCount: null },
+		});
+		expect(pass[0]).not.toHaveProperty('submissionId');
+	});
+
+	it('emits no decision or attempt change after a rejected stale replacement', async () => {
+		let raced = false;
+		const test = await setup(platform, {
+			count: 1,
+			afterRunningList: async (rows) => {
+				if (raced) return;
+				raced = true;
+				const row = rows[0];
+				if (!row?.attemptId) throw new Error('Missing stale test row');
+				await test.sqlStore.replaceSubmissionAttempt(
+					{ submissionId: row.submissionId, attemptId: row.attemptId },
+					generateAttemptId(),
+					{ ownerId: 'competitor', leaseExpiresAt: Date.now() + 60_000 },
+				);
+			},
+		});
+		await test.wake();
+		await test.idle();
+		expect(test.calls).toContain('replaceSubmissionAttempt');
+		expect(test.decisions()).toEqual([]);
+		expect(test.events.filter((event) => event.type === 'submission_attempt_changed')).toEqual([]);
+		expect(test.order).not.toContain('process');
+		expect((await test.sqlStore.getSubmission(test.input.submissionId))?.attemptCount).toBe(2);
+	});
+
+	it('contains thrown and rejected decision subscribers', async () => {
+		let thrown = 0;
+		let rejected = 0;
+		cleanups.push(
+			observe((event) => {
+				if (event.type === 'submission_recovery_decision') {
+					thrown++;
+					throw new Error('Local subscriber throw');
+				}
+			}),
+		);
+		cleanups.push(
+			observe(async (event) => {
+				if (event.type === 'submission_recovery_decision') {
+					rejected++;
+					throw new Error('Local subscriber rejection');
+				}
+			}),
+		);
+		const test = await setup(platform);
+		await test.wake();
+		await test.idle();
+		await drainGlobalEventDeliveries();
+		expect(thrown).toBe(1);
+		expect(rejected).toBe(1);
+		expect(test.decisions()).toHaveLength(1);
+		expect((await test.sqlStore.getSubmission(test.input.submissionId))?.status).toBe('settled');
+	});
+});
+
+function summary(error: unknown): Decision['error'] {
+	const decisions: Decision[] = [];
+	const stop = observe((event) => {
+		if (event.type === 'submission_recovery_decision') decisions.push(event);
+	});
+	try {
+		emitSubmissionRecoveryDecision(createCoordinatorEventEmitter({ env: {} }), {
+			operation: 'reconcile_pass',
+			reason: 'reconcile_failed',
+			error,
+		});
+		expect(decisions).toHaveLength(1);
+		expect(decisions[0]).not.toHaveProperty('errorInfo');
+		return decisions[0]?.error ?? null;
+	} finally {
+		stop();
+	}
+}
+
+describe('safe recovery causes', () => {
+	it('copies the first Boolean platform entry without wrapper fields', () => {
+		expect(
+			summary({
+				name: 'Wrapper',
+				remote: 'true',
+				message: 'private',
+				cause: { name: 'RpcError', retryable: false, cause: { name: 'Deeper', overloaded: true } },
+			}),
+		).toEqual({ name: 'RpcError', retryable: false, overloaded: null, remote: null });
+	});
+	it('keeps the first safe name when no entry has a Boolean flag', () => {
+		expect(summary({ name: 'Wrapper', retryable: 1, cause: new Error('private') })).toEqual({
+			name: 'Wrapper',
+			retryable: null,
+			overloaded: null,
+			remote: null,
+		});
+	});
+	it.each(['', 'Error with body', 'Error\n', 'Error\r', 'E'.repeat(81), '1Error'])(
+		'keeps invalid name %j unknown on a flagged entry',
+		(name) => {
+			expect(summary({ name: 'Wrapper', cause: { name, remote: true } })).toEqual({
+				name: null,
+				retryable: null,
+				overloaded: null,
+				remote: true,
+			});
+		},
+	);
+	it.each(['Rpc.Error-v2', '_Error', '$Error', 'E'.repeat(80)])('keeps valid name %j', (name) => {
+		expect(summary({ name })).toEqual({ name, retryable: null, overloaded: null, remote: null });
+	});
+	it.each([undefined, null, 'private text', 7, { message: 'private', retryable: 'true' }])(
+		'keeps unusable cause %j unknown',
+		(error) => {
+			expect(summary(error)).toBeNull();
+		},
+	);
+	it('contains property failures and never reads raw error detail', () => {
+		const unexpectedReads: string[] = [];
+		const error = {
+			get name() {
+				throw new Error('Local getter');
+			},
+			get overloaded() {
+				throw new Error('Local getter');
+			},
+			remote: false,
+			get message() {
+				unexpectedReads.push('message');
+				throw new Error('Must not read message');
+			},
+			get stack() {
+				unexpectedReads.push('stack');
+				throw new Error('Must not read stack');
+			},
+			get cause() {
+				unexpectedReads.push('cause');
+				throw new Error('Must not read past selected entry');
+			},
+		};
+		expect(summary(error)).toEqual({
+			name: null,
+			retryable: null,
+			overloaded: null,
+			remote: false,
+		});
+		expect(unexpectedReads).toEqual([]);
+		expect(
+			summary({
+				name: 'Outer',
+				get cause() {
+					throw new Error('Local cause getter');
+				},
+			}),
+		).toEqual({ name: 'Outer', retryable: null, overloaded: null, remote: null });
+	});
+	it('contains cycles and inspects no more than four entries', () => {
+		const cycle: { name: string; cause?: unknown } = { name: 'Outer' };
+		cycle.cause = cycle;
+		expect(summary(cycle)?.name).toBe('Outer');
+		let error: unknown = { name: 'Fifth', retryable: true };
+		for (let i = 0; i < 4; i++) error = { cause: error };
+		expect(summary(error)).toBeNull();
+		expect(summary({ cause: { cause: { cause: { name: 'Fourth', remote: true } } } })?.name).toBe(
+			'Fourth',
+		);
+	});
+	it('contains a throwing emitter', () => {
+		expect(() =>
+			emitSubmissionRecoveryDecision(
+				() => {
+					throw new Error('Local emitter');
+				},
+				{ operation: 'reconcile_pass', reason: 'reconcile_failed' },
+			),
+		).not.toThrow();
+	});
+});

--- a/packages/runtime/src/runtime/submission-recovery-state.test.ts
+++ b/packages/runtime/src/runtime/submission-recovery-state.test.ts
@@ -1,0 +1,231 @@
+import { afterEach, expect, it, vi } from 'vitest';
+import { createFlueContext } from '../client.ts';
+import { type ConversationRecord, encodeCanonicalId } from '../conversation-records.ts';
+import { getActiveConversationPath } from '../conversation-reducer.ts';
+import { ConversationRecordWriter } from '../conversation-writer.ts';
+import type { Harness } from '../harness.ts';
+import { observe } from '../index.ts';
+import { sqlite } from '../node/agent-execution-store.ts';
+import { Session } from '../session.ts';
+import type { FlueObservation } from '../types.ts';
+import { type AgentSubmissionInput, reconcileInterruptedSubmission } from './agent-submissions.ts';
+import { createCoordinatorEventEmitter, drainGlobalEventDeliveries } from './events.ts';
+import { generateAttemptId, generateSubmissionId } from './ids.ts';
+import { agentStreamPath } from './stream-offsets.ts';
+
+afterEach(() => vi.useRealTimers());
+
+it('preserves real transcripts, pending tool results, attempts, and settlement with reporting on or off', async () => {
+	vi.useFakeTimers({ toFake: ['Date'] });
+	vi.setSystemTime(new Date('2026-09-12T00:00:00Z'));
+	const input: AgentSubmissionInput = {
+		kind: 'direct',
+		submissionId: generateSubmissionId(),
+		agent: 'RecoveryAgent',
+		id: 'retained',
+		message: { kind: 'user', body: 'Local pending tool test' },
+		acceptedAt: new Date().toISOString(),
+	};
+	const attempt = { submissionId: input.submissionId, attemptId: generateAttemptId() };
+	async function recover(reporting: boolean) {
+		const persistence = sqlite();
+		await persistence.migrate?.();
+		const stores = await persistence.connect();
+		let session: Session | undefined;
+		const events: FlueObservation[] = [];
+		const stop = reporting
+			? observe((event) => {
+					events.push(event);
+				})
+			: () => {};
+		try {
+			await stores.submissionStore.admitDirect(input);
+			await stores.submissionStore.markSubmissionCanonicalReady(input.submissionId);
+			await stores.submissionStore.claimSubmission({
+				...attempt,
+				ownerId: 'test-producer',
+				leaseExpiresAt: Date.now() + 60_000,
+			});
+			await stores.submissionStore.markSubmissionInputApplied(attempt, {
+				maxAttempts: 1,
+				timeoutAt: Date.now() + 60_000,
+			});
+			let reads = 0;
+			// Keep the real SQL stream and count reads through its injected interface.
+			const stream = new Proxy(stores.conversationStreamStore, {
+				get(target, key) {
+					const value = Reflect.get(target, key);
+					if (typeof value !== 'function') return value;
+					return (...args: unknown[]) => {
+						if (key === 'read') reads++;
+						return Reflect.apply(value, target, args);
+					};
+				},
+			});
+			const writer = await ConversationRecordWriter.create({
+				store: stream,
+				path: agentStreamPath(input.agent, input.id),
+				identity: { agentName: input.agent, instanceId: input.id },
+				producerId: 'test-producer',
+			});
+			const scope = { conversationId: 'test-conversation', harness: 'default', session: 'default' };
+			await writer.ensureConversation({
+				...scope,
+				kind: 'root',
+				affinityKey: 'test',
+				createdAt: new Date().toISOString(),
+			});
+			const envelope = { ...scope, v: 1 as const, timestamp: new Date().toISOString(), ...attempt };
+			const inputId = `entry_direct_${encodeCanonicalId(input.submissionId)}`;
+			const records: ConversationRecord[] = [
+				{
+					...envelope,
+					id: 'record_input',
+					type: 'user_message',
+					messageId: inputId,
+					parentId: null,
+					content: [{ type: 'text', text: input.message.body }],
+				},
+				{
+					...envelope,
+					id: 'record_assistant',
+					type: 'assistant_message_started',
+					messageId: 'entry_assistant',
+					parentId: inputId,
+					modelInfo: { api: 'openai-completions', provider: 'test', model: 'local-model' },
+				},
+				{
+					...envelope,
+					id: 'record_tool',
+					type: 'assistant_tool_call',
+					messageId: 'entry_assistant',
+					blockId: 'tool-block',
+					blockIndex: 0,
+					toolCallId: 'pending-call',
+					name: 'local_tool',
+					arguments: {},
+				},
+				{
+					...envelope,
+					id: 'record_complete',
+					type: 'assistant_message_completed',
+					messageId: 'entry_assistant',
+					stopReason: 'toolUse',
+					usage: {
+						input: 0,
+						output: 0,
+						cacheRead: 0,
+						cacheWrite: 0,
+						totalTokens: 0,
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+					},
+				},
+			];
+			await writer.append(records, { submission: attempt });
+			const conversation = await writer.getConversation(scope.conversationId);
+			if (!conversation) throw new Error('Missing retained test conversation');
+			expect(conversation.toolOutcomes.size).toBe(0);
+			expect(
+				getActiveConversationPath(conversation).some(
+					(entry) =>
+						entry.type === 'message' &&
+						entry.message.role === 'assistant' &&
+						entry.message.content.some(
+							(block) => block.type === 'toolCall' && block.id === 'pending-call',
+						),
+				),
+			).toBe(true);
+			session = new Session({
+				name: 'default',
+				conversation,
+				conversationWriter: writer,
+				attachmentStore: stores.attachmentStore,
+				envSlot: { env: undefined, toolFactory: undefined, rediscoverNeeded: false },
+				config: {
+					systemPrompt: '',
+					skills: {},
+					resolveModel: () => undefined,
+					model: {
+						id: 'local-model',
+						name: 'Local model',
+						api: 'openai-completions',
+						provider: 'test',
+						baseUrl: 'https://unused.invalid',
+						reasoning: false,
+						input: ['text'],
+						cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+						contextWindow: 8192,
+						maxTokens: 100,
+					},
+				},
+			});
+			const realSession = session;
+			const createContext = () => {
+				const ctx = createFlueContext({
+					id: input.id,
+					agentName: input.agent,
+					submissionId: input.submissionId,
+					env: {},
+					agentConfig: { resolveModel: () => undefined },
+				});
+				// SAFETY: The session handler supports a directly injected internal Session.
+				ctx.initializeRootHarness = async () =>
+					({ session: async () => realSession }) as unknown as Harness;
+				return ctx;
+			};
+			const row = await stores.submissionStore.getSubmission(input.submissionId);
+			if (!row) throw new Error('Missing retained test submission');
+			const offset = writer.offset;
+			const readsBefore = reads;
+			await reconcileInterruptedSubmission(
+				stores.submissionStore,
+				row,
+				() => 'Local test',
+				createContext,
+				undefined,
+				writer,
+				reporting ? createCoordinatorEventEmitter({ env: {} }) : undefined,
+			);
+			await drainGlobalEventDeliveries();
+			const readsDuringRecovery = reads - readsBefore;
+			const settled = await stores.submissionStore.getSubmission(input.submissionId);
+			const reduced = await writer.getConversation(scope.conversationId);
+			if (!reduced) throw new Error('Missing settled test conversation');
+			const transcript = getActiveConversationPath(reduced).flatMap((entry) =>
+				entry.type === 'message' ? [entry.message] : [],
+			);
+			expect(transcript).toContainEqual(
+				expect.objectContaining({ role: 'toolResult', toolCallId: 'pending-call', isError: true }),
+			);
+			expect(reduced.toolOutcomes.size).toBe(0);
+			expect(settled?.status).toBe('settled');
+			expect(settled?.attemptCount).toBe(1);
+			expect(await stores.submissionStore.listPendingSubmissionSettlements()).toEqual([]);
+			if (reporting) {
+				expect(events.filter((event) => event.type === 'submission_recovery_decision')).toEqual([
+					expect.objectContaining({
+						reason: 'retry_exhausted',
+						position: { lastStreamOffset: offset, pendingToolCount: null },
+						error: null,
+					}),
+				]);
+			}
+			return {
+				transcript,
+				attemptId: settled?.attemptId,
+				count: settled?.attemptCount,
+				status: settled?.status,
+				error: settled?.error,
+				readsDuringRecovery,
+			};
+		} finally {
+			stop();
+			await session?.close();
+			await persistence.close?.();
+		}
+	}
+	const disabled = await recover(false);
+	const enabled = await recover(true);
+	expect(enabled).toEqual(disabled);
+	expect(enabled.readsDuringRecovery).toBe(0);
+});

--- a/packages/runtime/src/session-inspection.test.ts
+++ b/packages/runtime/src/session-inspection.test.ts
@@ -1,0 +1,107 @@
+import { expect, it, vi } from 'vitest';
+import { encodeCanonicalId } from './conversation-records.ts';
+import { ConversationRecordWriter } from './conversation-writer.ts';
+import { sqlite } from './node/agent-execution-store.ts';
+import type { AgentSubmissionInput } from './runtime/agent-submissions.ts';
+import { generateAttemptId, generateRecordId, generateSubmissionId } from './runtime/ids.ts';
+import { agentStreamPath } from './runtime/stream-offsets.ts';
+import { Session } from './session.ts';
+
+it('returns the existing inspection offset without another stream read or a guessed tool count', async () => {
+	const persistence = sqlite();
+	await persistence.migrate?.();
+	const stores = await persistence.connect();
+	let session: Session | undefined;
+	try {
+		const writer = await ConversationRecordWriter.create({
+			store: stores.conversationStreamStore,
+			path: agentStreamPath('InspectionAgent', 'test'),
+			identity: { agentName: 'InspectionAgent', instanceId: 'test' },
+			producerId: 'test-producer',
+		});
+		const scope = { conversationId: 'test-conversation', harness: 'default', session: 'default' };
+		await writer.ensureConversation({
+			...scope,
+			kind: 'root',
+			affinityKey: 'test-affinity',
+			createdAt: new Date().toISOString(),
+		});
+		const conversation = await writer.getConversation(scope.conversationId);
+		if (!conversation) throw new Error('Test conversation is missing');
+		session = new Session({
+			name: 'default',
+			conversation,
+			conversationWriter: writer,
+			attachmentStore: stores.attachmentStore,
+			envSlot: { env: undefined, toolFactory: undefined, rediscoverNeeded: false },
+			config: {
+				systemPrompt: '',
+				skills: {},
+				resolveModel: () => undefined,
+				model: {
+					id: 'test-model',
+					name: 'Test model',
+					api: 'openai-completions',
+					provider: 'test',
+					baseUrl: 'https://unused.invalid',
+					reasoning: false,
+					input: ['text'],
+					cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+					contextWindow: 8192,
+					maxTokens: 100,
+				},
+			},
+		});
+		const input: AgentSubmissionInput = {
+			kind: 'direct',
+			submissionId: generateSubmissionId(),
+			agent: 'InspectionAgent',
+			id: 'test',
+			message: { kind: 'user', body: 'Test input' },
+			acceptedAt: new Date().toISOString(),
+		};
+		const read = vi.spyOn(stores.conversationStreamStore, 'read');
+		const getConversation = vi.spyOn(writer, 'getConversation');
+		const initialOffset = writer.offset;
+		expect(await session.inspectSubmissionInput(input)).toEqual({
+			state: 'absent',
+			position: { lastStreamOffset: initialOffset, pendingToolCount: null },
+		});
+		await stores.submissionStore.admitDirect(input);
+		await stores.submissionStore.markSubmissionCanonicalReady(input.submissionId);
+		const attempt = { submissionId: input.submissionId, attemptId: generateAttemptId() };
+		await stores.submissionStore.claimSubmission({
+			...attempt,
+			ownerId: 'test-producer',
+			leaseExpiresAt: Date.now() + 60_000,
+		});
+		const appended = await writer.append(
+			[
+				{
+					...scope,
+					v: 1,
+					id: generateRecordId(),
+					type: 'user_message',
+					timestamp: new Date().toISOString(),
+					submissionId: input.submissionId,
+					attemptId: attempt.attemptId,
+					messageId: `entry_direct_${encodeCanonicalId(input.submissionId)}`,
+					parentId: null,
+					content: [{ type: 'text', text: input.message.body }],
+				},
+			],
+			{ submission: attempt },
+		);
+		expect(appended.offset).not.toBe(initialOffset);
+		expect(await session.inspectSubmissionInput(input)).toEqual({
+			state: 'interrupted',
+			position: { lastStreamOffset: appended.offset, pendingToolCount: null },
+		});
+		expect(getConversation).toHaveBeenCalledTimes(2);
+		expect(read).not.toHaveBeenCalled();
+	} finally {
+		await session?.close();
+		await persistence.close?.();
+		vi.restoreAllMocks();
+	}
+});

--- a/packages/runtime/src/session.ts
+++ b/packages/runtime/src/session.ts
@@ -151,6 +151,7 @@ import {
 import type {
 	AgentSubmissionInput,
 	AgentSubmissionInspection,
+	AgentSubmissionInspectionSnapshot,
 	AgentSubmissionInterruption,
 	AgentSubmissionSession,
 	InterruptedToolCallRef,
@@ -2734,14 +2735,24 @@ export class Session implements FlueSession, AgentSubmissionSession {
 		);
 	}
 
-	async inspectSubmissionInput(input: AgentSubmissionInput): Promise<AgentSubmissionInspection> {
+	async inspectSubmissionInput(
+		input: AgentSubmissionInput,
+	): Promise<AgentSubmissionInspectionSnapshot> {
 		const conversation = await this.conversationWriter.getConversation(this.conversationId);
-		if (!conversation?.entries.has(this.canonicalInputEntryId(input))) return 'absent';
-		return this.inspectCanonicalState(
-			classifyConversationSubmission(conversation, this.canonicalInputEntryId(input), {
-				contextWindow: this.agentLoop.state.model?.contextWindow ?? 0,
-			}),
-		);
+		return {
+			state: !conversation?.entries.has(this.canonicalInputEntryId(input))
+				? 'absent'
+				: this.inspectCanonicalState(
+						classifyConversationSubmission(conversation, this.canonicalInputEntryId(input), {
+							contextWindow: this.agentLoop.state.model?.contextWindow ?? 0,
+						}),
+					),
+			position: {
+				lastStreamOffset: this.conversationWriter.offset,
+				// This inspection does not count unresolved tool calls.
+				pendingToolCount: null,
+			},
+		};
 	}
 
 	processSubmissionInput(

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -1309,6 +1309,26 @@ type FlueEventVariant =
 			maxAttempts: number;
 	  }
 	| {
+			/** Recovery selected a failure or caught a reconciliation error.
+			 *  This live decision does not confirm terminal settlement. */
+			type: 'submission_recovery_decision';
+			submissionId?: string;
+			kind: 'dispatch' | 'direct' | null;
+			attempt: { attemptId: string | null; attemptCount: number } | null;
+			maxAttempts: number | null;
+			operation: 'reconcile_submission' | 'reconcile_pass';
+			reason: 'retry_exhausted' | 'timeout' | 'reconcile_failed';
+			/** Values from the existing inspection; null fields mean unknown. */
+			position: { lastStreamOffset: string | null; pendingToolCount: number | null };
+			/** Safe fields from one original cause entry, without error detail. */
+			error: {
+				name: string | null;
+				retryable: boolean | null;
+				overloaded: boolean | null;
+				remote: boolean | null;
+			} | null;
+	  }
+	| {
 			/** A coordinator recovery/reconciliation step failed (or skipped
 			 *  work) and was contained instead of settling the submission.
 			 *  Re-emitted on every failed wake while the condition persists;

--- a/packages/runtime/src/types.ts
+++ b/packages/runtime/src/types.ts
@@ -1281,6 +1281,23 @@ type FlueEventVariant =
 			kind: 'dispatch' | 'direct';
 	  }
 	| {
+			/** A guarded claim or replacement returned a new attempt, before
+			 *  execution starts. A process can stop after the store commits and
+			 *  before delivery; this live event has no replay guarantee. */
+			type: 'submission_attempt_changed';
+			submissionId: string;
+			kind: 'dispatch' | 'direct';
+			operation: 'claim_submission' | 'replace_submission_attempt';
+			/** The observed prior row, or null when a queued snapshot is stale. */
+			previous: { attemptId: string | null; attemptCount: number } | null;
+			/** Values copied from the row returned by the store. */
+			current: { attemptId: string; attemptCount: number };
+			maxAttempts: number;
+			reason: 'queued_claim' | 'interrupted_transcript';
+			/** The existing recovery inspection; null fields mean unknown. */
+			position: { lastStreamOffset: string | null; pendingToolCount: number | null };
+	  }
+	| {
 			/** An attempt started processing a claimed submission. Emitted on
 			 *  EVERY attempt — recovery replacements re-emit it with the
 			 *  incremented `attemptCount` — which is what lets an observer


### PR DESCRIPTION
Recovery can select budget or timeout failure, or catch a reconciliation error, without a distinct safe observer event. This adds `submission_recovery_decision` before terminal work and in the existing reconciliation catches, including the inner terminal-record catch. The event reports a choice or caught failure; the existing settlement record confirms the terminal result.

**Dependency: #674 at `14189f8c492dbb11c8ccde80070e76c2458f2747`.** This branch descends directly from its published branch, `zvs/run-7631-expose-committed-flue-submission-attempt-changes`. That commit stays unchanged. GitHub targets upstream `main`; the [RUN-7644-only diff](https://github.com/zvsdev/flue/compare/14189f8c492dbb11c8ccde80070e76c2458f2747...ead79d08fd22eceb5fceb52b8cda319d80101621) contains four production files, two sibling test files, and the events reference.

- Keep completion before abort, budget, and timeout. Keep attempt changes, queries, retries, execution, and settlement unchanged.
- Reuse the existing inspection snapshot. Missing submission fields and positions stay unknown.
- Copy safe name and Boolean platform flags from one cause entry, with at most four entries examined. Contain property failures, cycles, and subscriber failures. Copy no message, stack, body, request, or `errorInfo` detail.
- Preserve the separate PR675 cleanup hunk and RUN-7643 acknowledgment work.

Validation:

- All 64 runtime tests pass: 45 new regressions plus the 19 dependency regressions. Tests use both real coordinators and SQL stores. A real Session test compares retained transcripts, pending tool results, attempt counts, and settlement with reporting on and off, with no extra stream read.
- `pnpm check:types` passes all 109 workspace build/type tasks. The final runtime type check also passes.
- Biome passes all six changed TypeScript files. Prettier passes the new tests, public types, and event reference. Existing formatting outside the change stays intact. `git diff --check` passes.
- GitHub reports no required checks, status checks, automated reviews, or open review threads. The undrafted PR is CLEAN/MERGEABLE.
- `pnpm check` stops at the existing Knip listings: 48 unused development dependencies, 29 unused exports, and two unused exported types. These match the upstream-main limit recorded for #674.
- `pnpm test` stops at packages with no test files; this run first reports `@flue/redis`. The direct runtime suite passes. The repository-wide checks are not green, and this PR claims no waiver.

The complete fixer staff review covers correctness, design, privacy, tests, checks, and reader compatibility. It strengthens the raw-field access assertion, adds failed-settlement coverage, and removes unrelated formatting. No blocker, major, minor, or nit remains. Live delivery can still be lost during process failure; no stored delivery guarantee is added.

[RUN-7644](https://linear.app/runner-app/issue/RUN-7644/expose-safe-flue-failed-recovery-decisions), under RUN-5631. A future upstream release supplies diagnostic events only. It does not repair resets. Package publication and Runner adoption remain separate; this PR has no Runner deployment effect.
